### PR TITLE
Add prod deployment workflow (MIG)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,62 @@
+name: Deploy Backend to Prod (MIG)
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GCP_ZONE: us-east1-b
+  IMAGE: us-east1-docker.pkg.dev/v1-mvp/be-prod/be
+  MIG_NAME: instance-group-1
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-east1-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.IMAGE }}:${{ github.sha }} -t ${{ env.IMAGE }}:latest .
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Rolling update MIG
+        run: |
+          gcloud compute instance-groups managed rolling-action restart ${{ env.MIG_NAME }} \
+            --zone=${{ env.GCP_ZONE }}
+
+  notify:
+    needs: deploy
+    if: always()
+    uses: ./.github/workflows/discord-deploy-notify.yml
+    with:
+      status: ${{ needs.deploy.result }}
+      service: Backend (Prod)
+    secrets:
+      DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}


### PR DESCRIPTION
## What
Add GitHub Actions workflow (`deploy-prod.yml`) for production backend deployment using MIG rolling restart.

## Why
Need automated CI/CD pipeline for prod. On push to `main`, the workflow builds a Docker image, pushes to Artifact Registry (`be-prod/be`), and triggers a MIG rolling restart on `instance-group-1`.

## Related Issue
Closes #12