### PR TITLE
[Hotfix] Add /health endpoint for MIG health check

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -21,6 +21,11 @@ app.include_router(draft_router)
 def root():
     return {"message": "PPA-Dun backend is running"}
 
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
 # CORS 설정: 프론트엔드 개발 서버에서 백엔드 API에 요청할 수 있도록 허용 (프론트 주소에서 백 주소로 접근을 허용)
 # 그렇다고 해서 프론트의 VITE_API_BASE_URL가 필요 없는 것은 아님. 클라우드에 올리기 전까지는 프론트가 그렇게 설정해야 함.
 app.add_middleware(


### PR DESCRIPTION
## What
Add `/health` endpoint to FastAPI backend for MIG health check.

## Why
MIG health check probes `/health` but the endpoint didn't exist, causing instances to be marked unhealthy.

## Related Issue
Closes #15