### PR TITLE
Release: v0.2.2 - Fix draft room team naming

### DIFF
--- a/be/draft.py
+++ b/be/draft.py
@@ -239,8 +239,6 @@ def build_draft_teams(
     for i in range(opponents_count):
         if i < len(names) and names[i].strip():
             name = names[i].strip()
-        elif i == 0:
-            name = opp_team_name or "Opponent 1"
         else:
             name = f"Opponent {i + 1}"
         team_id = "team-opp" if i == 0 else f"team-{i + 2}"


### PR DESCRIPTION
## Summary
- Fix opponent team names to use consistent "Opponent 1", "Opponent 2", ... pattern
- Accept `oppTeamNames` as comma-separated query param so user-configured names are respected
- Remove special-case "Team A" fallback for first opponent

## Changes
- `draft.py` — `build_draft_teams()` updated to accept and use `oppTeamNames` list
- `/bootstrap` and `/teams` endpoints pass user-configured names through

## Related
- BE issue: #23
- FE issue: Ppa-Dun-project/PPA-DUN-fe#26