### PR TITLE
Chore: daily data update

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,12 +33,35 @@ jobs:
           docker push ${{ env.IMAGE }}:${{ github.sha }}
           docker push ${{ env.IMAGE }}:latest
 
-  notify:
+  update-helm:
     needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cloud repo
+        uses: actions/checkout@v4
+        with:
+          repository: Ppa-Dun-project/PPA-DUN-cloud
+          ref: infra/helm-chart-setup
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Update image tag
+        run: |
+          sed -i 's|tag: .*|tag: "${{ github.sha }}"|' helm/ppa-dun/values.yaml
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add helm/ppa-dun/values.yaml
+          git commit -m "deploy: update ppa-dun-be image to ${{ github.sha }}"
+          git push
+
+  notify:
+    needs: update-helm
     if: always()
     uses: ./.github/workflows/discord-deploy-notify.yml
     with:
-      status: ${{ needs.build-and-push.result }}
+      status: ${{ needs.update-helm.result }}
       service: Backend (Prod)
     secrets:
       DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Update image tag
         run: |
-          sed -i 's|tag: .*|tag: "${{ github.sha }}"|' helm/ppa-dun/values.yaml
+          sed -i '/ppaDunBe:/,/port:/ s|tag: .*|tag: "${{ github.sha }}"|' helm/ppa-dun/values.yaml
 
       - name: Commit and push
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Backend to Prod (MIG)
+name: Deploy Backend to Prod
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 env:
   GCP_REGION: us-east1
   IMAGE: us-east1-docker.pkg.dev/v1-mvp/be-prod/be
-  MIG_NAME: instance-group-1
 
 jobs:
   build-and-push:
@@ -34,29 +33,12 @@ jobs:
           docker push ${{ env.IMAGE }}:${{ github.sha }}
           docker push ${{ env.IMAGE }}:latest
 
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Rolling update MIG
-        run: |
-          gcloud compute instance-groups managed rolling-action restart ${{ env.MIG_NAME }} \
-            --region=${{ env.GCP_REGION }}
-
   notify:
-    needs: deploy
+    needs: build-and-push
     if: always()
     uses: ./.github/workflows/discord-deploy-notify.yml
     with:
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.build-and-push.result }}
       service: Backend (Prod)
     secrets:
       DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}

--- a/be/database/daily_update.py
+++ b/be/database/daily_update.py
@@ -1,0 +1,99 @@
+# daily_update.py — 매일 새벽에 실행하는 데이터 업데이트 스크립트.
+# injury, depth_charts, transactions 3개를 순차적으로 업데이트한다.
+#
+# 사용법:
+#   1) 직접 실행:  python daily_update.py
+#   2) 스케줄러:   python daily_update.py --scheduled  (매일 3AM ET 자동 실행)
+#   3) 외부 cron:  cron이나 Cloud Scheduler에서 1번 방식으로 호출
+import argparse
+import logging
+import sys
+from datetime import datetime
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def run_daily_update():
+    """injury, depth_charts, transactions를 순차적으로 업데이트한다."""
+    start = datetime.now()
+    logger.info("=== Daily update started ===")
+    results = {}
+
+    # 1. Injuries
+    try:
+        logger.info("[1/3] Updating injuries...")
+        from injury import fetch_and_store as update_injuries
+        update_injuries()
+        results["injuries"] = "OK"
+    except Exception as e:
+        logger.error(f"[1/3] Injuries failed: {e}")
+        results["injuries"] = f"FAILED: {e}"
+
+    # 2. Depth Charts
+    try:
+        logger.info("[2/3] Updating depth charts...")
+        from depth_charts import fetch_and_store as update_depth_charts
+        update_depth_charts()
+        results["depth_charts"] = "OK"
+    except Exception as e:
+        logger.error(f"[2/3] Depth charts failed: {e}")
+        results["depth_charts"] = f"FAILED: {e}"
+
+    # 3. Transactions
+    try:
+        logger.info("[3/3] Updating transactions...")
+        from transactions import fetch_and_store as update_transactions
+        update_transactions()
+        results["transactions"] = "OK"
+    except Exception as e:
+        logger.error(f"[3/3] Transactions failed: {e}")
+        results["transactions"] = f"FAILED: {e}"
+
+    elapsed = (datetime.now() - start).total_seconds()
+    logger.info(f"=== Daily update finished in {elapsed:.1f}s ===")
+    for name, status in results.items():
+        logger.info(f"  {name}: {status}")
+
+    return results
+
+
+def run_scheduled():
+    """매일 3AM ET에 자동 실행하는 스케줄러 모드."""
+    try:
+        from apscheduler.schedulers.blocking import BlockingScheduler
+        from apscheduler.triggers.cron import CronTrigger
+    except ImportError:
+        logger.error("apscheduler가 필요합니다: pip install apscheduler")
+        sys.exit(1)
+
+    scheduler = BlockingScheduler()
+    scheduler.add_job(
+        run_daily_update,
+        trigger=CronTrigger(hour=3, minute=0, timezone="EST"),
+        id="daily_update",
+        name="Daily MLB data update (3AM ET)",
+    )
+    logger.info("Scheduler started — next run at 3:00 AM EST daily")
+    logger.info("Press Ctrl+C to stop")
+
+    try:
+        scheduler.start()
+    except KeyboardInterrupt:
+        scheduler.shutdown()
+        logger.info("Scheduler stopped")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Daily MLB data updater")
+    parser.add_argument("--scheduled", action="store_true", help="Run as scheduler (3AM ET daily)")
+    args = parser.parse_args()
+
+    if args.scheduled:
+        run_scheduled()
+    else:
+        run_daily_update()

--- a/be/main.py
+++ b/be/main.py
@@ -1,5 +1,6 @@
 ﻿from draft import router as draft_router
 from home import router as home_router
+
 from myteam import router as myteam_router
 from ppa_router import router as ppa_router
 from players import router as players_router


### PR DESCRIPTION
## What
<!-- What did you do? -->

Added a daily scheduled update script (be/database/daily_update.py) that refreshes three data sources sequentially:
1. Injury status (ESPN API)
2. Depth charts (ESPN scraping)
3. Transactions (MLB StatsAPI)

The script supports two modes:
- Manual: python daily_update.py (run once)
- Scheduled: python daily_update.py --scheduled (runs automatically at 3:00 AM EST daily via APScheduler)

Each task runs independently — if one fails, the others still execute. Results are logged with success/failure status.

## Why
<!-- Why did you do it? -->

Injury status, depth charts, and transactions change daily during the MLB season. Without automated updates, the database would serve stale data. Scheduling at 3 AM EST ensures all games have ended and minimizes impact on users.

## Related Issue
<!-- e.g. #123 -->
- Backend Project: Ppa-Dun-project/PPA-DUN-be#28