### PR TITLE
feature: replace FPTS and real-time PPA API calls with DB-cached PPA …

### DIFF
--- a/be/database/ppa_value_bid.py
+++ b/be/database/ppa_value_bid.py
@@ -1,0 +1,205 @@
+# ppa_scores.py — 전체 선수의 PPA valueScore와 recommendedBid를 계산하여 DB에 저장하는 스크립트.
+# ppa_api/ppa_service.py를 통해 외부 API와 소통한다 (직접 호출하지 않음).
+# 사용법: python -m database.ppa_scores
+# 주기적으로 실행하여 player_ppa_scores 테이블을 갱신한다.
+import os
+import sys
+from datetime import datetime
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+DATABASE_URL = (
+    f"mysql+pymysql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+    f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+)
+engine = create_engine(DATABASE_URL)
+
+# ppa_api는 be/ 디렉토리에 있으므로 path 추가
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ppa_api.ppa_service import PpaAdapterService, PpaServiceError
+from ppa_api.ppa_schemas import (
+    BatterBidRequestIn,
+    BatterStatsIn,
+    DraftContextIn,
+    LeagueContextIn,
+    PitcherBidRequestIn,
+    PitcherStatsIn,
+)
+
+
+PITCHER_POSITIONS = {"P", "SP", "RP"}
+
+DEFAULT_LEAGUE_CONTEXT = LeagueContextIn(leagueSize=12, rosterSize=23, totalBudget=3120)
+
+DEFAULT_DRAFT_CONTEXT = DraftContextIn(
+    myRemainingBudget=260,
+    myRemainingRosterSpots=23,
+    myPositionsFilled=[],
+    draftedPlayersCount=0,
+)
+
+
+def _load_all_players():
+    """DB에서 active 선수 전체를 AL + NL 스탯과 함께 로드한다."""
+    players = []
+    seen_ids = set()
+
+    with engine.connect() as conn:
+        # AL stats (이름 직접 매칭)
+        al_rows = conn.execute(text("""
+            SELECT p.player_id, p.full_name, p.position, t.abbreviation,
+                   s.batting_average AS AVG, s.home_runs AS HR,
+                   s.runs_batted_in AS RBI, s.stolen_bases AS SB
+            FROM mlb_players_list p
+            JOIN players_stats_al_2025 s ON p.full_name = s.player_name
+            JOIN mlb_team_list t ON p.team_id = t.team_id
+            WHERE p.active = 1
+        """)).fetchall()
+
+        for row in al_rows:
+            pid = row._mapping["player_id"]
+            if pid not in seen_ids:
+                seen_ids.add(pid)
+                players.append(row)
+
+        # NL stats (Player 컬럼에서 이름 추출)
+        nl_rows = conn.execute(text("""
+            SELECT p.player_id, p.full_name, p.position, t.abbreviation,
+                   n.AVG, n.HR, n.RBI, n.SB
+            FROM (
+                SELECT
+                    TRIM(REGEXP_REPLACE(
+                        SUBSTRING_INDEX(Player, '|', 1),
+                        '(OF|SS|1B|2B|3B|C|CF|LF|RF|DH|P|U|SP|RP|IF|TWP)[, ].*$', ''
+                    )) AS player_name,
+                    AVG, HR, RBI, SB
+                FROM players_stats_nl_2025
+            ) n
+            JOIN mlb_players_list p ON p.full_name = n.player_name
+            JOIN mlb_team_list t ON p.team_id = t.team_id
+            WHERE p.active = 1
+        """)).fetchall()
+
+        for row in nl_rows:
+            pid = row._mapping["player_id"]
+            if pid not in seen_ids:
+                seen_ids.add(pid)
+                players.append(row)
+
+    return players
+
+
+def _build_batter_bid_request(name, position, stats):
+    """타자용 BatterBidRequestIn을 생성한다."""
+    hr = max(0, int(stats.get("HR") or 0))
+    rbi = max(0, int(stats.get("RBI") or 0))
+    sb = max(0, int(stats.get("SB") or 0))
+    avg = float(stats.get("AVG") or 0.250)
+    if avg <= 0:
+        avg = 0.250
+    runs = max(0, int(round((rbi * 0.55) + (hr * 0.8) + (sb * 0.3) + 30)))
+    cs = min(sb, max(0, int(round(sb * 0.25))))
+
+    pos = position.upper()
+    if pos in ("LF", "RF", "CF"):
+        pos = "OF"
+    if pos in ("TWP", "IF"):
+        pos = "DH"
+
+    return BatterBidRequestIn(
+        playerName=name,
+        playerType="batter",
+        position=pos,
+        stats=BatterStatsIn(AB=550, R=runs, HR=hr, RBI=rbi, SB=sb, CS=cs, AVG=avg),
+        leagueContext=DEFAULT_LEAGUE_CONTEXT,
+        draftContext=DEFAULT_DRAFT_CONTEXT,
+    )
+
+
+def _build_pitcher_bid_request(name, position):
+    """투수용 PitcherBidRequestIn을 생성한다."""
+    pos = "RP" if position.upper() == "RP" else "SP"
+    return PitcherBidRequestIn(
+        playerName=name,
+        playerType="pitcher",
+        position=pos,
+        stats=PitcherStatsIn(IP=170.0, W=10, SV=0, K=180, ERA=3.5, WHIP=1.15),
+        leagueContext=DEFAULT_LEAGUE_CONTEXT,
+        draftContext=DEFAULT_DRAFT_CONTEXT,
+    )
+
+
+def fetch_and_store():
+    """전체 선수를 PpaAdapterService를 통해 계산하고 DB에 저장한다."""
+    service = PpaAdapterService.from_settings()
+
+    rows = _load_all_players()
+    print(f"총 {len(rows)}명 선수를 PPA API로 전송합니다...")
+
+    now = datetime.utcnow()
+    success = 0
+    fail = 0
+
+    upsert_sql = text("""
+        INSERT INTO player_ppa_scores
+            (player_id, player_name, team, position, value_score, recommended_bid, updated_at)
+        VALUES
+            (:player_id, :player_name, :team, :position, :value_score, :recommended_bid, :updated_at)
+        ON DUPLICATE KEY UPDATE
+            player_name = VALUES(player_name),
+            team = VALUES(team),
+            position = VALUES(position),
+            value_score = VALUES(value_score),
+            recommended_bid = VALUES(recommended_bid),
+            updated_at = VALUES(updated_at)
+    """)
+
+    with engine.connect() as conn:
+        for row in rows:
+            r = row._mapping
+            player_id = r["player_id"]
+            name = r["full_name"]
+            position = r["position"] or "DH"
+            team = r["abbreviation"] or ""
+
+            try:
+                if position.upper() in PITCHER_POSITIONS:
+                    payload = _build_pitcher_bid_request(name, position)
+                else:
+                    stats = {"AVG": r["AVG"], "HR": r["HR"], "RBI": r["RBI"], "SB": r["SB"]}
+                    payload = _build_batter_bid_request(name, position, stats)
+
+                result = service.calculate_player_bid(payload)
+                value_score = float(result.playerValue)
+                recommended_bid = int(result.recommendedBid)
+                success += 1
+            except PpaServiceError as exc:
+                print(f"  FAIL: {name} — {exc.detail}")
+                value_score = 0.0
+                recommended_bid = 0
+                fail += 1
+            except Exception as exc:
+                print(f"  ERROR: {name} — {exc}")
+                value_score = 0.0
+                recommended_bid = 0
+                fail += 1
+
+            conn.execute(upsert_sql, {
+                "player_id": player_id,
+                "player_name": name,
+                "team": team,
+                "position": position,
+                "value_score": value_score,
+                "recommended_bid": recommended_bid,
+                "updated_at": now,
+            })
+
+        conn.commit()
+
+    print(f"완료: 성공 {success}명, 실패 {fail}명")
+
+
+if __name__ == "__main__":
+    fetch_and_store()

--- a/be/draft.py
+++ b/be/draft.py
@@ -1,21 +1,10 @@
 import logging
 from typing import Dict, List, Literal, Optional, Set, Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text as sa_text
 
-from ppa_api.ppa_schemas import (
-    BatterBidRequestIn,
-    BatterStatsIn,
-    DraftContextIn,
-    LeagueContextIn,
-    PitcherBidRequestIn,
-    PitcherStatsIn,
-)
-from ppa_api.ppa_service import PpaAdapterService, PpaServiceError, get_ppa_adapter_service
-
-from core.config import settings
 
 # Used by Draft page APIs (config/filters/teams/players/picks).
 router = APIRouter(prefix="/api/draft", tags=["draft"])
@@ -144,9 +133,13 @@ def _draft_position_filter_sql(position: str) -> str:
 # DB에서 드래프트 정렬용 SQL ORDER BY를 생성
 def _draft_sort_sql(sort: str) -> str:
     if sort == "score_desc":
-        return "ORDER BY COALESCE(s.FPTS, 0) DESC, p.full_name ASC"
+        return "ORDER BY COALESCE(ppa.value_score, 0) DESC, p.full_name ASC"
     if sort == "score_asc":
-        return "ORDER BY COALESCE(s.FPTS, 0) ASC, p.full_name ASC"
+        return "ORDER BY COALESCE(ppa.value_score, 0) ASC, p.full_name ASC"
+    if sort == "cost_desc":
+        return "ORDER BY COALESCE(ppa.value_score, 0) DESC, p.full_name ASC"
+    if sort == "cost_asc":
+        return "ORDER BY COALESCE(ppa.value_score, 0) ASC, p.full_name ASC"
     if sort == "avg_desc":
         return "ORDER BY COALESCE(s.AVG, 0) DESC, p.full_name ASC"
     if sort == "hr_desc":
@@ -155,14 +148,14 @@ def _draft_sort_sql(sort: str) -> str:
         return "ORDER BY COALESCE(s.RBI, 0) DESC, p.full_name ASC"
     if sort == "sb_desc":
         return "ORDER BY COALESCE(s.SB, 0) DESC, p.full_name ASC"
-    # cost_desc, cost_asc → PPA API enrichment 후 Python에서 정렬
-    return "ORDER BY COALESCE(s.FPTS, 0) DESC, p.full_name ASC"
+    return "ORDER BY COALESCE(ppa.value_score, 0) DESC, p.full_name ASC"
 
 
 _DRAFT_BASE_QUERY = """
     FROM mlb_players_list p
     LEFT JOIN mlb_team_list t ON p.team_id = t.team_id
     LEFT JOIN players_stats_nl_2025 s ON LOWER(s.Player) LIKE CONCAT(LOWER(p.full_name), ' %')
+    LEFT JOIN player_ppa_scores ppa ON p.player_id = ppa.player_id
     WHERE p.active = 1
 """
 
@@ -172,21 +165,20 @@ def _row_to_draft_player(row) -> DraftPlayerOut:
     r = row._mapping
     raw_pos = r["position"] or "DH"
     draft_pos = _DB_POS_TO_DRAFT.get(raw_pos, "UTIL")
-    fpts = float(r.get("FPTS") or 0)
-    # recommendedBid: FPTS 기반 임시 추정 (PPA API enrichment에서 덮어씀)
-    estimated_bid = max(1, int(fpts / 35)) if fpts > 0 else 1
+    ppa_value = float(r.get("value_score") or 0)
+    recommended_bid = int(r.get("recommended_bid") or 0)
 
     return DraftPlayerOut(
         id=str(r["player_id"]),
         name=r["full_name"],
         positions=[draft_pos],
-        recommendedBid=estimated_bid,
+        recommendedBid=max(1, recommended_bid) if recommended_bid > 0 else 1,
         team=r["abbreviation"] or "",
         avg=round(float(r.get("AVG") or 0), 3) or None,
         hr=int(r.get("HR") or 0) or None,
         rbi=int(r.get("RBI") or 0) or None,
         sb=int(r.get("SB") or 0) or None,
-        ppaValue=round(fpts, 1),
+        ppaValue=round(ppa_value, 1),
     )
 
 MOCK_DRAFT_POSITION_FILTERS: List[DraftPositionFilter] = [
@@ -240,14 +232,7 @@ ensure_draft_tables()
 # 인메모리 캐시 (성능용, 픽이 변경되면 초기화)
 ALLOWED_POSITIONS_CACHE: Dict[Tuple[str, str, str, int], List[DraftPosition]] = {}
 OCCUPIED_SLOTS_CACHE: Dict[str, Dict[str, Set[int]]] = {}
-PLAYER_MARKET_CACHE: Dict[
-    Tuple[str, int, int, int, int, int, int, Tuple[str, ...]],
-    Tuple[int, float],
-] = {}
-PITCHER_POSITIONS: Set[str] = {"SP", "RP"}
-BATTER_POSITIONS: Set[str] = {"C", "1B", "2B", "3B", "SS", "OF", "DH"}
 DEFAULT_MY_TEAM_ID = "team-0"
-MAX_EXTERNAL_BID_CALLS_PER_REQUEST = 40
 
 SLOT_TEMPLATE_BASE: List[DraftPosition] = [
     "SP",
@@ -318,182 +303,6 @@ def sort_draft_players(players: List[DraftPlayerOut], sort: DraftSort) -> List[D
     return players
 
 
-def is_external_bid_enabled() -> bool:
-    return bool(settings.EXTERNAL_API_BASE_URL and settings.EXTERNAL_API_KEY)
-
-
-def is_pitcher(player: DraftPlayerOut) -> bool:
-    return any(pos in PITCHER_POSITIONS for pos in player.positions)
-
-
-def to_external_position(player: DraftPlayerOut, pitcher: bool) -> str:
-    primary = player.positions[0] if player.positions else ("SP" if pitcher else "OF")
-    normalized = primary.upper()
-    if pitcher:
-        return "RP" if normalized == "RP" else "SP"
-    if normalized == "UTIL":
-        return "DH"
-    return normalized if normalized in BATTER_POSITIONS else "OF"
-
-
-def build_batter_stats(player: DraftPlayerOut) -> BatterStatsIn:
-    hr = max(0, int(player.hr or 0))
-    rbi = max(0, int(player.rbi or 0))
-    sb = max(0, int(player.sb or 0))
-    avg = float(player.avg or 0.250)
-    if avg <= 0:
-        avg = 0.250
-    runs = max(0, int(round((rbi * 0.55) + (hr * 0.8) + (sb * 0.3) + 30)))
-    caught_stealing = min(sb, max(0, int(round(sb * 0.25))))
-    return BatterStatsIn(
-        AB=550,
-        R=runs,
-        HR=hr,
-        RBI=rbi,
-        SB=sb,
-        CS=caught_stealing,
-        AVG=avg,
-    )
-
-
-def build_pitcher_stats(player: DraftPlayerOut) -> PitcherStatsIn:
-    # Keep payload generation independent from static ppaValue.
-    baseline_bid = max(1, int(player.recommendedBid or 1))
-    tier_scale = max(0.65, min(1.25, baseline_bid / 25.0))
-    is_relief = "RP" in player.positions
-    if is_relief:
-        ip = round(60.0 * tier_scale, 1)
-        wins = max(1, int(round(3 * tier_scale)))
-        saves = max(5, int(round(30 * tier_scale)))
-        strikeouts = max(35, int(round(80 * tier_scale)))
-        era = max(1.8, round(3.4 - ((tier_scale - 1.0) * 0.9), 2))
-        whip = max(0.85, round(1.12 - ((tier_scale - 1.0) * 0.16), 2))
-    else:
-        ip = round(170.0 * tier_scale, 1)
-        wins = max(3, int(round(11 * tier_scale)))
-        saves = 0
-        strikeouts = max(80, int(round(185 * tier_scale)))
-        era = max(2.2, round(3.8 - ((tier_scale - 1.0) * 0.9), 2))
-        whip = max(0.92, round(1.2 - ((tier_scale - 1.0) * 0.14), 2))
-    return PitcherStatsIn(
-        IP=ip,
-        W=wins,
-        SV=saves,
-        K=strikeouts,
-        ERA=era,
-        WHIP=whip,
-    )
-
-
-def build_league_context(
-    budget: int,
-    roster_slots: int,
-    opponents_count: int,
-) -> LeagueContextIn:
-    league_size = max(1, opponents_count + 1)
-    return LeagueContextIn(
-        leagueSize=league_size,
-        rosterSize=max(1, roster_slots),
-        totalBudget=max(1, budget * league_size),
-    )
-
-
-def build_draft_context(
-    user_id: str,
-    my_team_id: str,
-    budget: int,
-    roster_slots: int,
-) -> DraftContextIn:
-    picks = get_user_picks(user_id)
-    my_picks = [pick for pick in picks if pick.draftedByTeamId == my_team_id]
-    spent_budget = sum(pick.bid for pick in my_picks if isinstance(pick.bid, int))
-    return DraftContextIn(
-        myRemainingBudget=max(0, budget - spent_budget),
-        myRemainingRosterSpots=max(1, roster_slots - len(my_picks)),
-        myPositionsFilled=[pick.slotPos for pick in my_picks],
-        draftedPlayersCount=len(picks),
-    )
-
-
-def resolve_player_market_values(
-    player: DraftPlayerOut,
-    league_context: LeagueContextIn,
-    draft_context: DraftContextIn,
-    service: PpaAdapterService,
-) -> Tuple[int, float]:
-    cache_key = (
-        player.id,
-        league_context.leagueSize,
-        league_context.rosterSize,
-        league_context.totalBudget,
-        draft_context.myRemainingBudget,
-        draft_context.myRemainingRosterSpots,
-        draft_context.draftedPlayersCount,
-        tuple(draft_context.myPositionsFilled),
-    )
-    cached = PLAYER_MARKET_CACHE.get(cache_key)
-    if cached is not None:
-        return cached
-
-    pitcher = is_pitcher(player)
-    position = to_external_position(player, pitcher=pitcher)
-    try:
-        if pitcher:
-            payload = PitcherBidRequestIn(
-                playerName=player.name,
-                playerType="pitcher",
-                position=position,
-                stats=build_pitcher_stats(player),
-                leagueContext=league_context,
-                draftContext=draft_context,
-            )
-        else:
-            payload = BatterBidRequestIn(
-                playerName=player.name,
-                playerType="batter",
-                position=position,
-                stats=build_batter_stats(player),
-                leagueContext=league_context,
-                draftContext=draft_context,
-            )
-
-        response = service.calculate_player_bid(payload)
-        resolved_bid = max(1, int(getattr(response, "recommendedBid", player.recommendedBid)))
-        resolved_value = float(getattr(response, "playerValue", player.ppaValue))
-        resolved_pair = (resolved_bid, resolved_value)
-        PLAYER_MARKET_CACHE[cache_key] = resolved_pair
-        return resolved_pair
-    except PpaServiceError as exc:
-        logger.debug("Bid recommendation fallback for player=%s: %s", player.id, exc.detail)
-        return (player.recommendedBid, player.ppaValue)
-    except Exception:
-        logger.exception("Unexpected bid recommendation fallback for player=%s", player.id)
-        return (player.recommendedBid, player.ppaValue)
-
-
-def enrich_players_with_external_bid(
-    players: List[DraftPlayerOut],
-    league_context: LeagueContextIn,
-    draft_context: DraftContextIn,
-    service: PpaAdapterService,
-) -> List[DraftPlayerOut]:
-    enriched: List[DraftPlayerOut] = []
-    for player in players:
-        resolved_bid, resolved_value = resolve_player_market_values(
-            player=player,
-            league_context=league_context,
-            draft_context=draft_context,
-            service=service,
-        )
-        enriched.append(
-            player.model_copy(
-                update={
-                    "recommendedBid": resolved_bid,
-                    "ppaValue": resolved_value,
-                }
-            )
-        )
-    return enriched
 
 
 def clear_user_caches(user_id: str) -> None:
@@ -525,7 +334,7 @@ def find_draft_player(player_id: str) -> Optional[DraftPlayerOut]:
     from database.draft_store import engine
     sql = sa_text(f"""
         SELECT p.player_id, p.full_name, p.position, t.abbreviation,
-               s.AVG, s.HR, s.RBI, s.SB, s.FPTS
+               s.AVG, s.HR, s.RBI, s.SB, ppa.value_score, ppa.recommended_bid
         {_DRAFT_BASE_QUERY} AND p.player_id = :player_id
     """)
     with engine.connect() as conn:
@@ -656,12 +465,6 @@ def get_draft_players(
     sort: DraftSort = Query(default="score_desc"),
     page: int = Query(default=1, ge=1),
     limit: int = Query(default=50, ge=1),
-    user_id: str = Query(default="default", alias="userId"),
-    my_team_id: str = Query(default=DEFAULT_MY_TEAM_ID, alias="myTeamId"),
-    budget: int = Query(default=DEFAULT_DRAFT_CONFIG.budget, ge=50, le=600),
-    roster_players: int = Query(default=DEFAULT_DRAFT_CONFIG.rosterPlayers, alias="rosterPlayers", ge=8, le=len(SLOT_TEMPLATE_BASE)),
-    opponents_count: int = Query(default=DEFAULT_DRAFT_CONFIG.opponentsCount, alias="opponentsCount", ge=0, le=12),
-    service: PpaAdapterService = Depends(get_ppa_adapter_service),
 ):
     from database.draft_store import engine
 
@@ -697,7 +500,7 @@ def get_draft_players(
     # DATA
     data_sql = sa_text(f"""
         SELECT p.player_id, p.full_name, p.position, t.abbreviation,
-               s.AVG, s.HR, s.RBI, s.SB, s.FPTS
+               s.AVG, s.HR, s.RBI, s.SB, ppa.value_score, ppa.recommended_bid
         {_DRAFT_BASE_QUERY} {extra_where} {pos_sql}
         {sort_sql}
         LIMIT :limit OFFSET :offset
@@ -709,31 +512,6 @@ def get_draft_players(
         rows = conn.execute(data_sql, params).fetchall()
 
     paged = [_row_to_draft_player(r) for r in rows]
-
-    roster_slots = clamp_roster_slots(roster_players)
-    if is_external_bid_enabled() and paged:
-        league_context = build_league_context(
-            budget=budget,
-            roster_slots=roster_slots,
-            opponents_count=opponents_count,
-        )
-        draft_context = build_draft_context(
-            user_id=user_id,
-            my_team_id=my_team_id,
-            budget=budget,
-            roster_slots=roster_slots,
-        )
-        external_target = paged[:MAX_EXTERNAL_BID_CALLS_PER_REQUEST]
-        enriched = enrich_players_with_external_bid(
-            players=external_target,
-            league_context=league_context,
-            draft_context=draft_context,
-            service=service,
-        )
-        paged = enriched + paged[len(external_target):]
-
-        if sort in ("cost_desc", "cost_asc", "score_desc", "score_asc"):
-            paged = sort_draft_players(paged, sort)
 
     return DraftPlayerListResponse(
         items=paged,

--- a/be/home.py
+++ b/be/home.py
@@ -1,8 +1,18 @@
+import os
 from datetime import datetime, timedelta, timezone
 from typing import List
 
+from dotenv import load_dotenv
 from fastapi import APIRouter, Query
 from pydantic import BaseModel
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+DATABASE_URL = (
+    f"mysql+pymysql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}"
+    f"@{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
+)
+_engine = create_engine(DATABASE_URL)
 
 # Used by Home page sections (news/top players).
 router = APIRouter(prefix="/api", tags=["home"])
@@ -69,12 +79,38 @@ MOCK_NEWS_TEMPLATE = [
     ),
 ]
 
-MOCK_TOP_PLAYERS: List[TopPlayerOut] = [
-    TopPlayerOut(id="p1", name="Aaron Judge", team="NYY", positions=["OF"], valueScore=98.2),
-    TopPlayerOut(id="p2", name="Mookie Betts", team="LAD", positions=["2B", "OF"], valueScore=95.4),
-    TopPlayerOut(id="p3", name="Shohei Ohtani", team="LAD", positions=["DH"], valueScore=94.7),
-    TopPlayerOut(id="p4", name="Gerrit Cole", team="NYY", positions=["P"], valueScore=92.1),
-]
+_DB_POS_TO_DRAFT = {
+    "C": "C", "1B": "1B", "2B": "2B", "3B": "3B", "SS": "SS",
+    "LF": "OF", "RF": "OF", "CF": "OF", "OF": "OF",
+    "P": "SP", "SP": "SP", "RP": "RP",
+    "DH": "DH", "TWP": "DH", "IF": "UTIL",
+}
+
+
+def get_top_players_from_db(limit: int) -> List[TopPlayerOut]:
+    """player_ppa_scores 테이블에서 valueScore 상위 선수를 조회한다."""
+    sql = text("""
+        SELECT player_id, player_name, team, position, value_score
+        FROM player_ppa_scores
+        WHERE value_score > 0
+        ORDER BY value_score DESC
+        LIMIT :limit
+    """)
+    with _engine.connect() as conn:
+        rows = conn.execute(sql, {"limit": limit}).fetchall()
+
+    results: List[TopPlayerOut] = []
+    for row in rows:
+        r = row._mapping
+        pos = _DB_POS_TO_DRAFT.get((r["position"] or "DH").upper(), "UTIL")
+        results.append(TopPlayerOut(
+            id=str(r["player_id"]),
+            name=r["player_name"],
+            team=r["team"] or "",
+            positions=[pos],
+            valueScore=round(float(r["value_score"]), 1),
+        ))
+    return results
 
 
 def build_mock_news() -> List[NewsItemOut]:
@@ -102,7 +138,8 @@ def get_news(limit: int = Query(default=3, ge=1, le=20)):
 # Used by potential home ranking panel.
 @router.get("/top-players", response_model=TopPlayersResponse)
 def get_top_players(limit: int = Query(default=4, ge=1, le=50)):
-    return TopPlayersResponse(items=MOCK_TOP_PLAYERS[:limit], total=len(MOCK_TOP_PLAYERS))
+    players = get_top_players_from_db(limit)
+    return TopPlayersResponse(items=players, total=len(players))
 
 
 # Used when frontend wants one-call bootstrap for Home page.
@@ -112,5 +149,5 @@ def get_home_dashboard(
     top_players_limit: int = Query(default=4, ge=1, le=50),
 ):
     news = build_mock_news()[:news_limit]
-    top_players = MOCK_TOP_PLAYERS[:top_players_limit]
+    top_players = get_top_players_from_db(top_players_limit)
     return HomeDashboardResponse(news=news, topPlayers=top_players)

--- a/be/players.py
+++ b/be/players.py
@@ -126,15 +126,15 @@ def build_position_filter_sql(position: str) -> str:
 
 
 def build_sort_sql(sort: SortOrder) -> str:
-    """정렬 기준 SQL ORDER BY 절 반환 (FPTS 기반 valueScore 정렬 지원)"""
+    """정렬 기준 SQL ORDER BY 절 반환 (PPA valueScore 정렬 지원)"""
     if sort == "name_asc":
         return "ORDER BY p.full_name ASC"
     if sort == "name_desc":
         return "ORDER BY p.full_name DESC"
     if sort == "value_desc":
-        return "ORDER BY COALESCE(s.FPTS, 0) DESC, p.full_name ASC"
+        return "ORDER BY COALESCE(ppa.value_score, 0) DESC, p.full_name ASC"
     if sort == "value_asc":
-        return "ORDER BY COALESCE(s.FPTS, 0) ASC, p.full_name ASC"
+        return "ORDER BY COALESCE(ppa.value_score, 0) ASC, p.full_name ASC"
     return "ORDER BY p.full_name ASC"
 
 
@@ -143,14 +143,13 @@ def row_to_player_list_item(row) -> PlayerListItem:
     r = row._mapping
     raw_pos = r["position"] or "DH"
     display_pos = POSITION_TO_FILTER.get(raw_pos, raw_pos)
-    fpts = r.get("FPTS") or 0
 
     return PlayerListItem(
         id=r["player_id"],
         name=r["full_name"],
         team=r["abbreviation"] or "",
         positions=[display_pos],
-        valueScore=round(float(fpts), 1),
+        valueScore=round(float(r.get("value_score") or 0), 1),
         headshotUrl=f"https://img.mlbstatic.com/mlb-photos/image/upload/d_people:generic:headshot:67:current.png/w_213,q_auto:best/v1/people/{r['player_id']}/headshot/67/current",
     )
 
@@ -166,7 +165,6 @@ def row_to_player_out(row) -> PlayerOut:
     hr = r.get("HR") or 0
     obp = r.get("OBP") or 0.0
     slg = r.get("SLG") or 0.0
-    fpts = r.get("FPTS") or 0
 
     return PlayerOut(
         id=r["player_id"],
@@ -178,7 +176,7 @@ def row_to_player_out(row) -> PlayerOut:
         throws=r["pitch_hand"] or "R",
         team=r["abbreviation"] or "",
         positions=[display_pos],
-        valueScore=round(float(fpts), 1),
+        valueScore=round(float(r.get("value_score") or 0), 1),
         headshotUrl=f"https://img.mlbstatic.com/mlb-photos/image/upload/d_people:generic:headshot:67:current.png/w_213,q_auto:best/v1/people/{r['player_id']}/headshot/67/current",
         stats=PlayerStats(
             g=0,
@@ -200,26 +198,27 @@ def row_to_player_out(row) -> PlayerOut:
     )
 
 
-# 공통 JOIN 쿼리 베이스 (선수 + 팀 + 스탯)
+# 공통 JOIN 쿼리 베이스 (선수 + 팀 + 스탯 + PPA 스코어)
 BASE_QUERY = """
     FROM mlb_players_list p
     LEFT JOIN mlb_team_list t ON p.team_id = t.team_id
     LEFT JOIN players_stats_nl_2025 s ON LOWER(s.Player) LIKE CONCAT(LOWER(p.full_name), ' %')
+    LEFT JOIN player_ppa_scores ppa ON p.player_id = ppa.player_id
     WHERE p.active = 1
 """
 
-# 리스트용 SELECT (스탯 테이블에서 FPTS만)
+# 리스트용 SELECT (PPA valueScore 포함)
 LIST_SELECT = """
     SELECT p.player_id, p.full_name, p.current_age, p.height, p.weight,
            p.bat_side, p.pitch_hand, p.position, t.abbreviation,
-           s.FPTS
+           ppa.value_score
 """
 
-# 상세용 SELECT (스탯 테이블 전체)
+# 상세용 SELECT (스탯 + PPA valueScore)
 DETAIL_SELECT = """
     SELECT p.*, t.abbreviation,
            s.AB, s.R, s.H, s.HR, s.RBI, s.BB, s.K, s.SB,
-           s.AVG, s.OBP, s.SLG, s.FPTS
+           s.AVG, s.OBP, s.SLG, ppa.value_score
 """
 
 
@@ -318,44 +317,20 @@ class PlayerValueResponse(BaseModel):
 
 @router.get("/{player_id}/value", response_model=PlayerValueResponse)
 def get_player_value(player_id: int):
-    detail_sql = f"""
-        {DETAIL_SELECT}
-        {BASE_QUERY} AND p.player_id = :player_id
-    """
+    # player_ppa_scores 테이블에서 PPA API가 계산한 valueScore를 조회한다.
+    ppa_sql = text("""
+        SELECT player_name, value_score
+        FROM player_ppa_scores
+        WHERE player_id = :player_id
+    """)
     with engine.connect() as conn:
-        row = conn.execute(text(detail_sql), {"player_id": player_id}).fetchone()
+        row = conn.execute(ppa_sql, {"player_id": player_id}).fetchone()
 
     if not row:
-        raise HTTPException(status_code=404, detail="Player not found")
-
-    player = row_to_player_out(row)
-
-    # PPA API로 진짜 valueScore 계산
-    try:
-        from ppa_api.ppa_service import PpaAdapterService
-        from ppa_api.ppa_schemas import (
-            BatterValueRequestIn, BatterStatsIn, LeagueContextIn,
-        )
-
-        svc = PpaAdapterService.from_settings()
-        payload = BatterValueRequestIn(
-            playerName=player.name,
-            playerType="batter",
-            position=player.positions[0],
-            stats=BatterStatsIn(
-                AB=player.stats.ab, R=player.stats.r, HR=player.stats.hr,
-                RBI=player.stats.rbi, SB=player.stats.sb, CS=0, AVG=player.stats.avg,
-            ),
-            leagueContext=LeagueContextIn(leagueSize=6, rosterSize=23, totalBudget=260),
-        )
-        result = svc.calculate_player_value(payload)
-        value_score = round(result.playerValue, 1)
-    except Exception as e:
-        logger.warning(f"PPA API call failed for {player.name}: {e}")
-        value_score = player.valueScore  # FPTS fallback
+        raise HTTPException(status_code=404, detail="Player PPA score not found")
 
     return PlayerValueResponse(
-        playerId=player.id,
-        name=player.name,
-        valueScore=value_score,
+        playerId=player_id,
+        name=row._mapping["player_name"],
+        valueScore=round(float(row._mapping["value_score"]), 1),
     )


### PR DESCRIPTION
…scores

## What
<!-- What did you do? -->
- Add ppa_value_bid.py script to batch-calculate value_score and recommended_bid via PpaAdapterService and store in player_ppa_scores table
- draft.py: remove all real-time PPA API enrichment functions, read value_score and recommended_bid from player_ppa_scores JOIN
- players.py: replace FPTS-based valueScore with ppa.value_score, /value endpoint now reads from DB instead of calling PPA API
- home.py: replace MOCK_TOP_PLAYERS with DB query on player_ppa_scores

## Why
<!-- Why did you do it? -->
- There were a lot of unnecessary duplicated API calls in several files.
- Only the files starting with "ppa_" would directly communicate with the API server (ppa_client, ppa_router, ppa_schemas, ppa_service)
- Other files would refer to the data that has already been received and stored in the database via the files above.

## Related Issue
<!-- e.g. #123 -->
- #30 