### PR TITLE
bugfix: correct import path in main.py

### DIFF
--- a/be/main.py
+++ b/be/main.py
@@ -5,7 +5,7 @@ from auth import router as auth_router
 from draft import router as draft_router
 from home import router as home_router
 from myteam import router as myteam_router
-from backend.be.playerinfo import router as players_router
+from playerinfo import router as players_router
 
 from core.config import settings
 from db.session import engine, Base


### PR DESCRIPTION
## Summary
- Fix ModuleNotFoundError causing BE pod to crash on startup
- Change import from `backend.be.playerinfo` to `playerinfo`

Closes #52

## Test plan
- [ ] Verify BE pod starts without crashing on prod
- [ ] Verify /api/players endpoints respond correctly