### PR TITLE
fix: sync /app/cl to infra/helm-chart-setup in deploy-dev workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -52,7 +52,9 @@ jobs:
             --command="sudo gcloud auth configure-docker us-east1-docker.pkg.dev --quiet && \
                        sudo docker pull ${{ env.IMAGE }}:latest && \
                        sudo git config --global --add safe.directory /app/cl && \
-                       cd /app/cl && sudo git pull origin main && \
+                       cd /app/cl && \
+                       sudo git fetch origin infra/helm-chart-setup && \
+                       sudo git reset --hard origin/infra/helm-chart-setup && \
                        cd /app/cl/dev && sudo docker compose up -d be"
 
   notify:


### PR DESCRIPTION
## What
Change the deploy-dev workflow's server-side git sync from `git pull origin main` to `git fetch + reset --hard origin/infra/helm-chart-setup`.

## Why
v1-dev's `/app/cl` tracks `infra/helm-chart-setup` (ArgoCD source), not `main`. `git pull origin main` was a silent no-op while `origin/main` was stagnant, and failed with divergent-branches the moment `origin/main` moved forward. `reset --hard` is idempotent and kills the failure class.

## Related Issue
Closes #64