### PR TITLE
feature: implemented pitcher data importing from API, calculating and responding to the frontend #79

### DIFF
--- a/be/database/player_cache_store.py
+++ b/be/database/player_cache_store.py
@@ -1,22 +1,20 @@
-# Player cache table backed by the external API GET /players endpoint.
-# refresh_player_cache() pulls the AL+NL rosters and upserts into player_caching.
-# Scheduled daily by APScheduler in main.py; no manual trigger endpoint.
+# Batter and pitcher cache tables backed by the external PPA API.
+# refresh_player_cache() pulls AL+NL batters and pitchers and upserts local cache.
 import asyncio
 import logging
+from typing import Any
 
-from sqlalchemy import (
-    Column, Float, Integer, MetaData, String, Table,
-    inspect, text,
-)
+from sqlalchemy import text
 
 from orm.session import engine
 from ppa_api.ppa_client import build_ppa_api_client
 
 logger = logging.getLogger(__name__)
 
-# 외부 API GET /players 응답에서 받아 cache 테이블에 저장할 컬럼들.
-# 순서가 INSERT placeholder 와 매칭되므로 변경 시 양쪽 같이 업데이트.
-_CACHE_COLUMNS = (
+BATTER_CACHE_TABLE = "batter_caching"
+PITCHER_CACHE_TABLE = "pitcher_caching"
+
+_BATTER_CACHE_COLUMNS = (
     "player_id", "name", "position", "team",
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date",
@@ -27,85 +25,34 @@ _CACHE_COLUMNS = (
     "injury_status", "depth_order", "player_value",
 )
 
-
-def ensure_player_cache_table() -> None:
-    inspector = inspect(engine)
-    if inspector.has_table("player_caching"):
-        return
-
-    metadata = MetaData()
-    Table(
-        "player_caching", metadata,
-        Column("player_id", Integer, primary_key=True),
-        Column("name", String(100)),
-        Column("position", String(10)),
-        Column("team", String(10)),
-        Column("primary_number", String(10)),
-        Column("birth_date", String(20)),
-        Column("birth_city", String(100)),
-        Column("birth_country", String(100)),
-        Column("height", String(20)),
-        Column("weight", Integer),
-        Column("current_age", Integer),
-        Column("mlb_debut_date", String(20)),
-        Column("bat_side", String(5)),
-        Column("pitch_hand", String(5)),
-        Column("ab", Integer),
-        Column("r", Integer),
-        Column("h", Integer),
-        Column("single", Integer),
-        Column("double", Integer),
-        Column("triple", Integer),
-        Column("hr", Integer),
-        Column("rbi", Integer),
-        Column("bb", Integer),
-        Column("k", Integer),
-        Column("sb", Integer),
-        Column("cs", Integer),
-        Column("avg", Float),
-        Column("obp", Float),
-        Column("slg", Float),
-        Column("injury_status", String(50)),
-        Column("depth_order", Integer),
-        Column("player_value", Float),
-    )
-    metadata.create_all(engine)
-    print("Table created: player_caching")
+_PITCHER_CACHE_COLUMNS = (
+    "player_id", "name", "position", "team",
+    "w", "sv", "so", "era", "whip", "ip",
+    "injury_status", "depth_order", "player_value",
+    "l", "g", "gs", "war", "fip", "h", "r", "er", "hr", "bb", "hbp", "bf",
+    "era_plus", "h9", "hr9", "bb9", "so9", "so_bb",
+    "primary_number", "birth_date", "birth_city", "birth_country",
+    "height", "weight", "current_age", "mlb_debut_date", "pitch_hand",
+)
 
 
-# AL/NL 전체 선수 목록을 외부 API에서 받아 player_caching 테이블에 UPSERT.
-# 실패 시 로그만 남기고 기존 cache 유지 (다음 스케줄 때 재시도). API 응답에 사라진
-# 선수도 cache에는 그대로 남음 (stale 허용).
-async def refresh_player_cache() -> None:
-    client = build_ppa_api_client()
-    try:
-        al_resp, nl_resp = await asyncio.gather(
-            client.players_by_league("AL", columns=_CACHE_COLUMNS),
-            client.players_by_league("NL", columns=_CACHE_COLUMNS),
-        )
-    except Exception as exc:
-        logger.warning("player cache refresh failed: %s", exc)
-        return
+def _extract_rows(response: dict[str, Any], preferred_key: str) -> list[dict[str, Any]]:
+    rows = response.get(preferred_key)
+    if rows is None:
+        rows = response.get("players")
+    if not isinstance(rows, list):
+        return []
+    return [row for row in rows if isinstance(row, dict)]
 
-    players = (al_resp.get("players") or []) + (nl_resp.get("players") or [])
-    rows = [
-        {col: p.get(col) for col in _CACHE_COLUMNS}
-        for p in players
-        if p.get("player_id") is not None
-    ]
 
-    if not rows:
-        logger.warning("player cache refresh: no players returned from API")
-        return
-
-    # MariaDB/MySQL 예약어 (예: double) 가 컬럼명에 포함되어 있으므로 모든 컬럼명을 backtick으로 감쌈.
-    quoted_cols = ", ".join(f"`{c}`" for c in _CACHE_COLUMNS)
-    placeholders = ", ".join(f":{c}" for c in _CACHE_COLUMNS)
+def _upsert_cache_rows(table_name: str, columns: tuple[str, ...], rows: list[dict[str, Any]]) -> None:
+    quoted_cols = ", ".join(f"`{col}`" for col in columns)
+    placeholders = ", ".join(f":{col}" for col in columns)
     update_clause = ", ".join(
-        f"`{c}` = VALUES(`{c}`)" for c in _CACHE_COLUMNS if c != "player_id"
+        f"`{col}` = VALUES(`{col}`)" for col in columns if col != "player_id"
     )
     sql = text(f"""
-        INSERT INTO player_caching ({quoted_cols})
+        INSERT INTO {table_name} ({quoted_cols})
         VALUES ({placeholders})
         ON DUPLICATE KEY UPDATE {update_clause}
     """)
@@ -113,4 +60,61 @@ async def refresh_player_cache() -> None:
     with engine.begin() as conn:
         conn.execute(sql, rows)
 
-    logger.info("player cache refresh: %d players upserted", len(rows))
+
+async def refresh_batter_cache() -> None:
+    client = build_ppa_api_client()
+    try:
+        al_resp, nl_resp = await asyncio.gather(
+            client.batters_by_league("AL", columns=_BATTER_CACHE_COLUMNS),
+            client.batters_by_league("NL", columns=_BATTER_CACHE_COLUMNS),
+        )
+    except Exception as exc:
+        logger.warning("batter cache refresh failed: %s", exc)
+        return
+
+    batters = _extract_rows(al_resp, "batters") + _extract_rows(nl_resp, "batters")
+    rows = [
+        {col: batter.get(col) for col in _BATTER_CACHE_COLUMNS}
+        for batter in batters
+        if batter.get("player_id") is not None
+    ]
+
+    if not rows:
+        logger.warning("batter cache refresh: no batters returned from API")
+        return
+
+    _upsert_cache_rows(BATTER_CACHE_TABLE, _BATTER_CACHE_COLUMNS, rows)
+    logger.info("batter cache refresh: %d batters upserted", len(rows))
+
+
+async def refresh_pitcher_cache() -> None:
+    client = build_ppa_api_client()
+    try:
+        al_resp, nl_resp = await asyncio.gather(
+            client.pitchers_by_league("AL", columns=_PITCHER_CACHE_COLUMNS),
+            client.pitchers_by_league("NL", columns=_PITCHER_CACHE_COLUMNS),
+        )
+    except Exception as exc:
+        logger.warning("pitcher cache refresh failed: %s", exc)
+        return
+
+    pitchers = _extract_rows(al_resp, "pitchers") + _extract_rows(nl_resp, "pitchers")
+    rows = [
+        {col: pitcher.get(col) for col in _PITCHER_CACHE_COLUMNS}
+        for pitcher in pitchers
+        if pitcher.get("player_id") is not None
+    ]
+
+    if not rows:
+        logger.warning("pitcher cache refresh: no pitchers returned from API")
+        return
+
+    _upsert_cache_rows(PITCHER_CACHE_TABLE, _PITCHER_CACHE_COLUMNS, rows)
+    logger.info("pitcher cache refresh: %d pitchers upserted", len(rows))
+
+
+async def refresh_player_cache() -> None:
+    await asyncio.gather(
+        refresh_batter_cache(),
+        refresh_pitcher_cache(),
+    )

--- a/be/database/players_lookup.py
+++ b/be/database/players_lookup.py
@@ -1,5 +1,5 @@
 # Read-only lookups for player id → (name, position, team) translation.
-# Backed by player_caching, which mirrors the external API's player roster.
+# Backed by batter_caching and pitcher_caching, which mirror the external API roster.
 # Position values match the API convention (e.g., "OF" not split into LF/CF/RF).
 
 from typing import Optional
@@ -18,8 +18,17 @@ def get_player_by_id(player_id: str) -> Optional[tuple[str, str, str]]:
 
     sql = sa_text("""
         SELECT name, position, team
-        FROM player_caching
-        WHERE player_id = :player_id
+        FROM (
+            SELECT name, position, team, 0 AS priority
+            FROM batter_caching
+            WHERE player_id = :player_id
+            UNION ALL
+            SELECT name, position, team, 1 AS priority
+            FROM pitcher_caching
+            WHERE player_id = :player_id
+        ) AS player_lookup
+        ORDER BY priority
+        LIMIT 1
     """)
     with engine.connect() as conn:
         row = conn.execute(sql, {"player_id": normalized_id}).fetchone()

--- a/be/main.py
+++ b/be/main.py
@@ -14,7 +14,7 @@ from pages.home import router as home_router
 from pages.myteam import router as myteam_router
 from pages.playerinfo import router as players_router
 
-from database.player_cache_store import ensure_player_cache_table, refresh_player_cache
+from database.player_cache_store import refresh_player_cache
 from orm.session import engine, Base
 from orm.models import User  # noqa: F401 — import so SQLAlchemy registers the table
 
@@ -24,13 +24,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 load_dotenv()
 
-# Auto-create all DB tables on startup (if they don't exist yet)
+# Auto-create ORM-managed DB tables on startup (if they don't exist yet)
 Base.metadata.create_all(bind=engine)
-ensure_player_cache_table()
 
 
-# player_caching 테이블을 매일 04:00 ET (America/New_York, DST 자동 반영)에 갱신.
-# 외부 API에서 AL+NL 선수 목록을 받아 UPSERT.
+# batter_caching/pitcher_caching 테이블을 매일 04:00 ET (America/New_York, DST 자동 반영)에 갱신.
+# 외부 API에서 AL+NL 타자/투수 목록을 받아 UPSERT.
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     scheduler = AsyncIOScheduler()

--- a/be/pages/ai.py
+++ b/be/pages/ai.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from vertexai import init as vertexai_init
 from vertexai.generative_models import GenerativeModel
 
@@ -30,6 +30,9 @@ def _get_model() -> GenerativeModel:
 
 class PlayerInput(BaseModel):
     name: str
+    playerType: Optional[str] = None
+    team: Optional[str] = None
+    positions: list[str] = Field(default_factory=list)
     ppaValue: float
     recommendedBid: int
     stats: dict
@@ -54,13 +57,19 @@ def _build_prompt(a: PlayerInput, b: PlayerInput) -> str:
     return (
         "Compare these two MLB fantasy baseball players and recommend which is the "
         "better draft pick in 2-3 concise sentences. Focus on value per dollar "
-        "and key stats.\n\n"
+        "and key stats. If a player is a pitcher, interpret ERA and WHIP as lower-is-better.\n\n"
         f"Player A: {a.name}\n"
+        f"  Type: {a.playerType or 'unknown'}\n"
+        f"  Team: {a.team or 'unknown'}\n"
+        f"  Positions: {a.positions}\n"
         f"  PPA Value: {a.ppaValue}\n"
         f"  Recommended Bid: ${a.recommendedBid}\n"
         f"  Value Per Dollar: {_value_per_dollar(a)}\n"
         f"  Stats: {a.stats}\n\n"
         f"Player B: {b.name}\n"
+        f"  Type: {b.playerType or 'unknown'}\n"
+        f"  Team: {b.team or 'unknown'}\n"
+        f"  Positions: {b.positions}\n"
         f"  PPA Value: {b.ppaValue}\n"
         f"  Recommended Bid: ${b.recommendedBid}\n"
         f"  Value Per Dollar: {_value_per_dollar(b)}\n"

--- a/be/pages/draft.py
+++ b/be/pages/draft.py
@@ -1,8 +1,8 @@
 # Draft page API router.
 # Handles draft configuration, player listing, pick registration/deletion (persisted to DB),
 # slot assignment, and bootstrap.
-# Player metadata and value come from the player_caching table; recommended bids
-# are computed in real time via the external API's POST /player/bid/name.
+# Player metadata and value come from the batter_caching table; recommended bids
+# are computed in real time via the external API's POST /player/bid/id.
 import asyncio
 import logging
 from datetime import datetime
@@ -24,18 +24,26 @@ router = APIRouter(prefix="/api/draft", tags=["draft"])
 
 DraftPosition = Literal["C", "1B", "2B", "3B", "SS", "OF", "UTIL", "SP", "RP", "BENCH"]
 DraftPickType = Literal["mine", "taken"]
+PlayerType = Literal["batter", "pitcher", "two_way"]
 
 # 선수별 드래프트 관련 정보 + 간단 개인 스탯
 # 공통 요소 집합
 class PlayerSummary(BaseModel):
     id: str
     name: str
+    playerType: PlayerType
     positions: List[DraftPosition]
     team: str
     avg: Optional[float] = None
     hr: Optional[int] = None
     rbi: Optional[int] = None
     sb: Optional[int] = None
+    w: Optional[int] = None
+    sv: Optional[int] = None
+    so: Optional[int] = None
+    era: Optional[float] = None
+    whip: Optional[float] = None
+    ip: Optional[float] = None
 
 # 드래프트 세션 설정에 관한 값들
 class DraftConfig(BaseModel):
@@ -124,7 +132,8 @@ _DB_POS_TO_DRAFT: Dict[str, DraftPosition] = {
     "C": "C", "1B": "1B", "2B": "2B", "3B": "3B", "SS": "SS",
     "OF": "OF", "LF": "OF", "CF": "OF", "RF": "OF",
     "DH": "UTIL", "TWP": "UTIL", "IF": "SS",
-    "P": "SP",
+    "P": "SP", "SP": "SP", "RP": "RP", "CL": "RP",
+    "LHP": "SP", "RHP": "SP",
 }
 
 # DB-backed draft storage
@@ -144,6 +153,24 @@ from database.draft_store import (
 # Clamps a number to a given range. Ensures user input stays within valid bounds.
 def clamp_int(value: int, min_value: int, max_value: int) -> int:
     return max(min_value, min(max_value, int(value)))
+
+
+def nullable_int(value) -> Optional[int]:
+    if value is None:
+        return None
+    parsed = int(value)
+    return parsed or None
+
+
+def nullable_float(value, digits: int = 3) -> Optional[float]:
+    if value is None:
+        return None
+    parsed = round(float(value), digits)
+    return parsed or None
+
+
+def draft_position_for(raw_position: str | None, fallback: DraftPosition) -> DraftPosition:
+    return _DB_POS_TO_DRAFT.get((raw_position or "").upper(), fallback)
 
 
 # Builds the list of teams for a draft room.
@@ -400,30 +427,69 @@ def delete_user_session(
 # 현역 batter 전체를 player_caching에서 반환. 필터/정렬/페이지네이션은 프론트에서 처리.
 @router.get("/players", response_model=PlayerSummaryList)
 def get_draft_players():
-    sql = sa_text("""
+    batter_sql = sa_text("""
         SELECT player_id, name, position, team, avg, hr, rbi, sb
-        FROM player_caching
+        FROM batter_caching
     """)
-    with engine.connect() as conn:
-        rows = conn.execute(sql).fetchall()
+    pitcher_sql = sa_text("""
+        SELECT player_id, name, position, team, w, sv, so, era, whip, ip
+        FROM pitcher_caching
+    """)
 
-    items = []
-    for row in rows:
+    with engine.connect() as conn:
+        batter_rows = conn.execute(batter_sql).fetchall()
+        pitcher_rows = conn.execute(pitcher_sql).fetchall()
+
+    items_by_id: Dict[int, PlayerSummary] = {}
+
+    for row in batter_rows:
         m = row._mapping
-        raw_pos = m["position"] or "DH"
-        draft_pos = _DB_POS_TO_DRAFT.get(raw_pos, "UTIL")
-        items.append(PlayerSummary(
+        player_id = int(m["player_id"])
+        draft_pos = draft_position_for(m["position"], "UTIL")
+        items_by_id[player_id] = PlayerSummary(
             id=str(m["player_id"]),
-            name=m["name"],
+            name=m["name"] or "",
+            playerType="batter",
             positions=[draft_pos],
             team=m["team"] or "",
-            avg=round(float(m["avg"] or 0), 3) or None,
-            hr=int(m["hr"] or 0) or None,
-            rbi=int(m["rbi"] or 0) or None,
-            sb=int(m["sb"] or 0) or None,
-        ))
+            avg=nullable_float(m["avg"]),
+            hr=nullable_int(m["hr"]),
+            rbi=nullable_int(m["rbi"]),
+            sb=nullable_int(m["sb"]),
+        )
 
-    return PlayerSummaryList(items=items)
+    for row in pitcher_rows:
+        m = row._mapping
+        player_id = int(m["player_id"])
+        draft_pos = draft_position_for(m["position"], "SP")
+        existing = items_by_id.get(player_id)
+        if existing is not None:
+            existing.playerType = "two_way"
+            if draft_pos not in existing.positions:
+                existing.positions.append(draft_pos)
+            existing.w = nullable_int(m["w"])
+            existing.sv = nullable_int(m["sv"])
+            existing.so = nullable_int(m["so"])
+            existing.era = nullable_float(m["era"], 2)
+            existing.whip = nullable_float(m["whip"], 3)
+            existing.ip = nullable_float(m["ip"], 1)
+            continue
+
+        items_by_id[player_id] = PlayerSummary(
+            id=str(m["player_id"]),
+            name=m["name"] or "",
+            playerType="pitcher",
+            positions=[draft_pos],
+            team=m["team"] or "",
+            w=nullable_int(m["w"]),
+            sv=nullable_int(m["sv"]),
+            so=nullable_int(m["so"]),
+            era=nullable_float(m["era"], 2),
+            whip=nullable_float(m["whip"], 3),
+            ip=nullable_float(m["ip"], 1),
+        )
+
+    return PlayerSummaryList(items=list(items_by_id.values()))
 
 
 
@@ -439,8 +505,16 @@ async def get_draft_player_values(
     config = payload.config
     picks = payload.picks
 
-    # 로컬 DB cache: 활성 batter (id + player_value) 한 번에 조회
-    sql = sa_text("SELECT player_id, player_value FROM player_caching")
+    # Local DB cache: active batters + pitchers. Two-way players are collapsed to one row.
+    sql = sa_text("""
+        SELECT player_id, MAX(player_value) AS player_value
+        FROM (
+            SELECT player_id, player_value FROM batter_caching
+            UNION ALL
+            SELECT player_id, player_value FROM pitcher_caching
+        ) AS player_values
+        GROUP BY player_id
+    """)
     with engine.connect() as conn:
         cache_rows = conn.execute(sql).fetchall()
 

--- a/be/pages/home.py
+++ b/be/pages/home.py
@@ -30,8 +30,15 @@ def list_injured(limit: Optional[int] = None):
     sql = (
         "SELECT player_id, name, position, team, primary_number, "
         "       injury_status, player_value "
-        "FROM player_caching "
-        "WHERE injury_status IS NOT NULL "
+        "FROM ("
+        "  SELECT player_id, name, position, team, primary_number, injury_status, player_value "
+        "  FROM batter_caching "
+        "  WHERE injury_status IS NOT NULL "
+        "  UNION ALL "
+        "  SELECT player_id, name, position, team, primary_number, injury_status, player_value "
+        "  FROM pitcher_caching "
+        "  WHERE injury_status IS NOT NULL "
+        ") AS injured_players "
         "ORDER BY player_value DESC"
     )
     params: dict = {}

--- a/be/pages/myteam.py
+++ b/be/pages/myteam.py
@@ -1,7 +1,7 @@
 # My Team page API router.
 # Returns the selected draft session's roster and budget summary.
 # Filtering, sorting, and pagination are handled by the frontend.
-from typing import List
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
@@ -14,10 +14,13 @@ from security import get_user_id
 
 router = APIRouter(prefix="/api/my-team", tags=["my-team"])
 
+PlayerType = Literal["batter", "pitcher"]
+
 
 class MyTeamPlayerOut(BaseModel):
     id: str
     name: str
+    playerType: PlayerType
     pos: str
     cost: int
     team: str
@@ -25,6 +28,12 @@ class MyTeamPlayerOut(BaseModel):
     hr: int
     rbi: int
     sb: int
+    w: Optional[int] = None
+    sv: Optional[int] = None
+    so: Optional[int] = None
+    era: Optional[float] = None
+    whip: Optional[float] = None
+    ip: Optional[float] = None
     ppaValue: float
 
 
@@ -36,7 +45,7 @@ class MyTeamPlayersResponse(BaseModel):
 
 
 def pick_my_players(session_id: int) -> List[MyTeamPlayerOut]:
-    # Load the session's picks, then enrich only my roster rows from player_caching.
+    # Load the session's picks, then enrich my roster rows from batter/pitcher caches.
     picks = get_session_picks(session_id)
     mine = sorted(
         (pick for pick in picks if pick.draftedByTeamId == "team-0"),
@@ -47,20 +56,37 @@ def pick_my_players(session_id: int) -> List[MyTeamPlayerOut]:
         return []
 
     player_ids = [int(pick.playerId) for pick in mine]
-    sql = sa_text("""
+    batter_sql = sa_text("""
         SELECT player_id, position, team, avg, hr, rbi, sb, player_value, name
-        FROM player_caching
+        FROM batter_caching
+        WHERE player_id IN :ids
+    """).bindparams(bindparam("ids", expanding=True))
+    pitcher_sql = sa_text("""
+        SELECT player_id, position, team, w, sv, so, era, whip, ip, player_value, name
+        FROM pitcher_caching
         WHERE player_id IN :ids
     """).bindparams(bindparam("ids", expanding=True))
 
     with engine.connect() as conn:
-        rows = conn.execute(sql, {"ids": player_ids}).fetchall()
+        batter_rows = conn.execute(batter_sql, {"ids": player_ids}).fetchall()
+        pitcher_rows = conn.execute(pitcher_sql, {"ids": player_ids}).fetchall()
 
-    cache_by_id = {row._mapping["player_id"]: row._mapping for row in rows}
+    batters_by_id = {row._mapping["player_id"]: row._mapping for row in batter_rows}
+    pitchers_by_id = {row._mapping["player_id"]: row._mapping for row in pitcher_rows}
 
     items: List[MyTeamPlayerOut] = []
     for pick in mine:
-        player = cache_by_id.get(int(pick.playerId))
+        normalized_id = int(pick.playerId)
+        wants_pitcher = pick.slotPos in ("SP", "RP")
+        player_type: PlayerType = "pitcher" if wants_pitcher and normalized_id in pitchers_by_id else "batter"
+        player = pitchers_by_id.get(normalized_id) if player_type == "pitcher" else batters_by_id.get(normalized_id)
+        if not player and player_type == "batter":
+            player_type = "pitcher"
+            player = pitchers_by_id.get(normalized_id)
+        elif not player:
+            player_type = "batter"
+            player = batters_by_id.get(normalized_id)
+
         if not player:
             continue
 
@@ -75,13 +101,20 @@ def pick_my_players(session_id: int) -> List[MyTeamPlayerOut]:
             MyTeamPlayerOut(
                 id=str(player["player_id"]),
                 name=player["name"],
+                playerType=player_type,
                 pos=display_pos,
                 cost=int(pick.bid or 0),
                 team=player["team"] or "",
-                avg=float(player["avg"] or 0.0),
-                hr=int(player["hr"] or 0),
-                rbi=int(player["rbi"] or 0),
-                sb=int(player["sb"] or 0),
+                avg=float(player["avg"] or 0.0) if player_type == "batter" else 0.0,
+                hr=int(player["hr"] or 0) if player_type == "batter" else 0,
+                rbi=int(player["rbi"] or 0) if player_type == "batter" else 0,
+                sb=int(player["sb"] or 0) if player_type == "batter" else 0,
+                w=int(player["w"] or 0) if player_type == "pitcher" else None,
+                sv=int(player["sv"] or 0) if player_type == "pitcher" else None,
+                so=int(player["so"] or 0) if player_type == "pitcher" else None,
+                era=round(float(player["era"] or 0.0), 2) if player_type == "pitcher" else None,
+                whip=round(float(player["whip"] or 0.0), 3) if player_type == "pitcher" else None,
+                ip=round(float(player["ip"] or 0.0), 1) if player_type == "pitcher" else None,
                 ppaValue=float(player["player_value"] or 0.0),
             )
         )

--- a/be/pages/playerinfo.py
+++ b/be/pages/playerinfo.py
@@ -1,11 +1,10 @@
 # Players page API router.
-# Provides player detail with full stats and a per-player value endpoint.
-# All data is read from the player_caching table.
+# Provides player detail views from batter_caching or pitcher_caching.
 import logging
 import re
-from typing import List, Optional
+from typing import Literal, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -13,106 +12,212 @@ from orm.session import engine
 
 logger = logging.getLogger(__name__)
 
-# Used by Player pages. This router owns player list/detail/filter APIs.
 router = APIRouter(prefix="/api/players", tags=["players"])
 
+PlayerType = Literal["batter", "pitcher"]
 
-# Used by PlayerDetail page. Detailed stat block for a single player.
-class PlayerStats(BaseModel):
-    g: int              # 경기 수
-    pa: int             # 타석 수
-    hr: int             # 홈런 수
-    ops: float          # OPS (출루율 + 장타율)
-    ip: float = 0.0     # 투구 이닝 (투수인 경우)
-    
-    # Additional batting stats
-    ab: int = 0         # 타수
-    r: int = 0          # 득점
-    h: int = 0          # 안타
-    rbi: int = 0        # 타점
-    bb: int = 0         # 볼넷
-    k: int = 0          # 삼진
-    sb: int = 0         # 도루
-    cs: int = 0         # 도루 실패 (Caught Stealing)
-    avg: float = 0.0    # 타율
-    obp: float = 0.0    # 출루율
-    slg: float = 0.0    # 장타율
 
-# Used by PlayerDetail page. Full data for a single player.
+class BatterStats(BaseModel):
+    avg: float = 0.0
+    pa: int = 0
+    hr: int = 0
+    ops: float = 0.0
+    rbi: int = 0
+    ab: int = 0
+    r: int = 0
+    h: int = 0
+    bb: int = 0
+    k: int = 0
+    sb: int = 0
+    cs: int = 0
+    obp: float = 0.0
+    slg: float = 0.0
+
+
+class PitcherStats(BaseModel):
+    w: int = 0
+    sv: int = 0
+    so: int = 0
+    era: float = 0.0
+    whip: float = 0.0
+    ip: float = 0.0
+    l: int = 0
+    g: int = 0
+    gs: int = 0
+    war: float = 0.0
+    fip: float = 0.0
+    h: int = 0
+    r: int = 0
+    er: int = 0
+    hr: int = 0
+    bb: int = 0
+    hbp: int = 0
+    bf: int = 0
+    era_plus: int = 0
+    h9: float = 0.0
+    hr9: float = 0.0
+    bb9: float = 0.0
+    so9: float = 0.0
+    so_bb: float = 0.0
+
+
 class PlayerOut(BaseModel):
     id: int
+    playerType: PlayerType
     name: str
     age: int
     height_in: int
     weight_lb: int
-    bats: str
+    bats: Optional[str] = None
     throws: str
     team: str
-    positions: List[str]
+    positions: list[str]
     valueScore: float
     headshotUrl: Optional[str] = None
-    stats: PlayerStats
+    batterStats: Optional[BatterStats] = None
+    pitcherStats: Optional[PitcherStats] = None
 
 
-def parse_height_to_inches(height_str: str) -> int:
+def parse_height_to_inches(height_str: str | None) -> int:
     match = re.match(r"(\d+)'\s*(\d+)\"?", height_str or "")
     if match:
         return int(match.group(1)) * 12 + int(match.group(2))
     return 0
 
 
-# player_caching 테이블에서 선수의 personal info + 통합 스탯 + value를 단일 쿼리로 조회.
-@router.get("/{player_id}", response_model=PlayerOut)
-def get_player_detail(player_id: int):
+def headshot_url(player_id: int) -> str:
+    return (
+        "https://img.mlbstatic.com/mlb-photos/image/upload/"
+        "d_people:generic:headshot:67:current.png/"
+        f"w_213,q_auto:best/v1/people/{player_id}/headshot/67/current"
+    )
+
+
+def int_value(value) -> int:
+    return int(value or 0)
+
+
+def float_value(value, digits: int = 3) -> float:
+    return round(float(value or 0.0), digits)
+
+
+def build_batter_detail(player_id: int) -> PlayerOut:
     sql = text("""
         SELECT player_id, name, position, team,
                current_age, height, weight, bat_side, pitch_hand,
                ab, r, h, hr, rbi, bb, k, sb, cs,
                avg, obp, slg, player_value
-        FROM player_caching
+        FROM batter_caching
         WHERE player_id = :player_id
     """)
     with engine.connect() as conn:
         row = conn.execute(sql, {"player_id": player_id}).fetchone()
 
     if not row:
-        raise HTTPException(status_code=404, detail="Player not found")
+        raise HTTPException(status_code=404, detail="Batter not found")
 
     m = row._mapping
-    ab = m["ab"] or 0
-    bb = m["bb"] or 0
-    obp = m["obp"] or 0.0
-    slg = m["slg"] or 0.0
+    ab = int_value(m["ab"])
+    bb = int_value(m["bb"])
+    obp = float_value(m["obp"])
+    slg = float_value(m["slg"])
 
     return PlayerOut(
         id=m["player_id"],
-        name=m["name"],
-        age=m["current_age"] or 0,
+        playerType="batter",
+        name=m["name"] or "",
+        age=int_value(m["current_age"]),
         height_in=parse_height_to_inches(m["height"]),
-        weight_lb=m["weight"] or 0,
+        weight_lb=int_value(m["weight"]),
         bats=m["bat_side"] or "R",
         throws=m["pitch_hand"] or "R",
         team=m["team"] or "",
         positions=[m["position"] or "DH"],
-        valueScore=float(m["player_value"] or 0.0),
-        headshotUrl=f"https://img.mlbstatic.com/mlb-photos/image/upload/d_people:generic:headshot:67:current.png/w_213,q_auto:best/v1/people/{m['player_id']}/headshot/67/current",
-        stats=PlayerStats(
-            g=0,
+        valueScore=float_value(m["player_value"]),
+        headshotUrl=headshot_url(m["player_id"]),
+        batterStats=BatterStats(
+            avg=float_value(m["avg"]),
             pa=ab + bb,
-            hr=m["hr"] or 0,
+            hr=int_value(m["hr"]),
             ops=round(obp + slg, 3),
-            ip=0.0,
+            rbi=int_value(m["rbi"]),
             ab=ab,
-            r=m["r"] or 0,
-            h=m["h"] or 0,
-            rbi=m["rbi"] or 0,
+            r=int_value(m["r"]),
+            h=int_value(m["h"]),
             bb=bb,
-            k=m["k"] or 0,
-            sb=m["sb"] or 0,
-            cs=m["cs"] or 0,
-            avg=round(float(m["avg"] or 0.0), 3),
-            obp=round(float(obp), 3),
-            slg=round(float(slg), 3),
+            k=int_value(m["k"]),
+            sb=int_value(m["sb"]),
+            cs=int_value(m["cs"]),
+            obp=obp,
+            slg=slg,
         ),
     )
 
+
+def build_pitcher_detail(player_id: int) -> PlayerOut:
+    sql = text("""
+        SELECT player_id, name, position, team,
+               current_age, height, weight, pitch_hand, player_value,
+               w, sv, so, era, whip, ip,
+               l, g, gs, war, fip, h, r, er, hr, bb, hbp, bf,
+               era_plus, h9, hr9, bb9, so9, so_bb
+        FROM pitcher_caching
+        WHERE player_id = :player_id
+    """)
+    with engine.connect() as conn:
+        row = conn.execute(sql, {"player_id": player_id}).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Pitcher not found")
+
+    m = row._mapping
+    return PlayerOut(
+        id=m["player_id"],
+        playerType="pitcher",
+        name=m["name"] or "",
+        age=int_value(m["current_age"]),
+        height_in=parse_height_to_inches(m["height"]),
+        weight_lb=int_value(m["weight"]),
+        bats=None,
+        throws=m["pitch_hand"] or "R",
+        team=m["team"] or "",
+        positions=[m["position"] or "P"],
+        valueScore=float_value(m["player_value"]),
+        headshotUrl=headshot_url(m["player_id"]),
+        pitcherStats=PitcherStats(
+            w=int_value(m["w"]),
+            sv=int_value(m["sv"]),
+            so=int_value(m["so"]),
+            era=float_value(m["era"], 2),
+            whip=float_value(m["whip"], 3),
+            ip=float_value(m["ip"], 1),
+            l=int_value(m["l"]),
+            g=int_value(m["g"]),
+            gs=int_value(m["gs"]),
+            war=float_value(m["war"]),
+            fip=float_value(m["fip"], 2),
+            h=int_value(m["h"]),
+            r=int_value(m["r"]),
+            er=int_value(m["er"]),
+            hr=int_value(m["hr"]),
+            bb=int_value(m["bb"]),
+            hbp=int_value(m["hbp"]),
+            bf=int_value(m["bf"]),
+            era_plus=int_value(m["era_plus"]),
+            h9=float_value(m["h9"], 2),
+            hr9=float_value(m["hr9"], 2),
+            bb9=float_value(m["bb9"], 2),
+            so9=float_value(m["so9"], 2),
+            so_bb=float_value(m["so_bb"], 2),
+        ),
+    )
+
+
+@router.get("/{player_id}", response_model=PlayerOut)
+def get_player_detail(
+    player_id: int,
+    playerType: PlayerType = Query("batter"),
+):
+    if playerType == "pitcher":
+        return build_pitcher_detail(player_id)
+    return build_batter_detail(player_id)

--- a/be/ppa_api/ppa_client.py
+++ b/be/ppa_api/ppa_client.py
@@ -1,5 +1,5 @@
 # Async HTTP client for the external PPA valuation API.
-# Sends requests to /health, /player/value, /player/bid, /players, /players/{name}
+# Sends requests to /health, /player/bid/id, /players/batters, /players/pitchers
 # using httpx.AsyncClient.
 # Defines exception classes (HTTP errors, timeouts, invalid responses)
 # so the service layer can map them to appropriate HTTP status codes.
@@ -91,12 +91,13 @@ class PpaApiClient:
     # 야구 선수 입찰가 추천. payload 형식은 호출자 책임.
     # 신규 스펙: {player_id, league_context, draft_context: {..., my_positions_filled}}
     async def player_bid(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self.request_json("POST", "/player/bid/name", body=payload, requires_auth=True)
+        return await self.request_json("POST", "/player/bid/id", body=payload, requires_auth=True)
 
     # 리그 전체 선수 목록 + valuation score 조회
     # league는 "AL" 또는 "NL", columns는 반환받을 필드 이름 리스트 (None이면 API 기본값 사용)
-    async def players_by_league(
+    async def _players_by_league(
         self,
+        path: str,
         league: str,
         columns: Optional[Iterable[str]] = None,
     ) -> dict[str, Any]:
@@ -109,11 +110,25 @@ class PpaApiClient:
 
         return await self.request_json(
             "GET",
-            "/players",
+            path,
             body=None,
             requires_auth=True,
             query_params=query_params,
         )
+
+    async def batters_by_league(
+        self,
+        league: str,
+        columns: Optional[Iterable[str]] = None,
+    ) -> dict[str, Any]:
+        return await self._players_by_league("/players/batters", league, columns)
+
+    async def pitchers_by_league(
+        self,
+        league: str,
+        columns: Optional[Iterable[str]] = None,
+    ) -> dict[str, Any]:
+        return await self._players_by_league("/players/pitchers", league, columns)
 
     ############## HTTP 요청을 보내고 응답 받는 형식 생성 ###############
     # API 서버와 주고 받을 형식 구상, 요청 전송 및 응답 처리


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Split player cache/API handling into batter and pitcher flows, using batter_caching and pitcher_caching with updated external API endpoints for batters, pitchers, and bid-by-player-id.
- Added pitcher support across draft, my team, player lookup, home injured players, and player detail APIs, including pitcher-specific stats and playerType handling where needed.
- Updated comparison/AI support so batter-vs-batter and pitcher-vs-pitcher comparisons use role-appropriate stats, while AI payloads include player type, team, positions, and relevant stats.

## Why
<!-- Why did you do it? -->
- The external player API now separates batters and pitchers, so the backend needed to align with the new endpoint and cache structure.
- Pitcher data must behave consistently with batter data across draft workflows, roster views, detail pages, and recommendation features.

## Related Issue
<!-- e.g. #123 -->
- #79 