### PR TITLE
chore: league type distinguishing in fetching player data from API server

### DIFF
--- a/be/database/player_cache_store.py
+++ b/be/database/player_cache_store.py
@@ -12,7 +12,8 @@ from ppa_api.ppa_client import build_ppa_api_client
 logger = logging.getLogger(__name__)
 
 
-_BATTER_CACHE_COLUMNS = (
+# API에서 받아오는 필드 (league는 query 필터라서 반환 컬럼이 아님 → 여기 포함 안 함)
+_BATTER_API_COLUMNS = (
     "player_id", "name", "position", "team",
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date",
@@ -23,7 +24,7 @@ _BATTER_CACHE_COLUMNS = (
     "injury_status", "depth_order", "player_value",
 )
 
-_PITCHER_CACHE_COLUMNS = (
+_PITCHER_API_COLUMNS = (
     "player_id", "name", "position", "team",
     "w", "sv", "so", "era", "whip", "ip",
     "injury_status", "depth_order", "player_value",
@@ -32,6 +33,10 @@ _PITCHER_CACHE_COLUMNS = (
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date", "pitch_hand",
 )
+
+# DB 캐시 테이블에 저장하는 컬럼 = API 필드 + 우리가 태깅하는 league
+_BATTER_CACHE_COLUMNS = _BATTER_API_COLUMNS + ("league",)
+_PITCHER_CACHE_COLUMNS = _PITCHER_API_COLUMNS + ("league",)
 
 
 def _extract_rows(response: dict[str, Any], preferred_key: str) -> list[dict[str, Any]]:
@@ -81,7 +86,10 @@ def _sync_cache_table(
         )
         return
 
-    items = _extract_rows(al_resp, rows_key) + _extract_rows(nl_resp, rows_key)
+    items = (
+        [{**r, "league": "AL"} for r in _extract_rows(al_resp, rows_key)]
+        + [{**r, "league": "NL"} for r in _extract_rows(nl_resp, rows_key)]
+    )
     rows = [
         {col: item.get(col) for col in columns}
         for item in items
@@ -105,8 +113,8 @@ def _sync_cache_table(
 async def refresh_batter_cache() -> None:
     client = build_ppa_api_client()
     al_resp, nl_resp = await asyncio.gather(
-        client.batters_by_league("AL", columns=_BATTER_CACHE_COLUMNS),
-        client.batters_by_league("NL", columns=_BATTER_CACHE_COLUMNS),
+        client.batters_by_league("AL", columns=_BATTER_API_COLUMNS),
+        client.batters_by_league("NL", columns=_BATTER_API_COLUMNS),
         return_exceptions=True,
     )
     _sync_cache_table(
@@ -122,8 +130,8 @@ async def refresh_batter_cache() -> None:
 async def refresh_pitcher_cache() -> None:
     client = build_ppa_api_client()
     al_resp, nl_resp = await asyncio.gather(
-        client.pitchers_by_league("AL", columns=_PITCHER_CACHE_COLUMNS),
-        client.pitchers_by_league("NL", columns=_PITCHER_CACHE_COLUMNS),
+        client.pitchers_by_league("AL", columns=_PITCHER_API_COLUMNS),
+        client.pitchers_by_league("NL", columns=_PITCHER_API_COLUMNS),
         return_exceptions=True,
     )
     _sync_cache_table(

--- a/be/pages/draft.py
+++ b/be/pages/draft.py
@@ -448,20 +448,25 @@ def delete_user_session(
 
 ############################ 선수 데이터 #############################
 # 현역 batter 전체를 player_caching에서 반환. 필터/정렬/페이지네이션은 프론트에서 처리.
+# league 쿼리 파라미터로 "AL" / "NL" 지정 시 해당 리그 선수만 반환. 미지정 시 전체.
 @router.get("/players", response_model=PlayerSummaryList)
-def get_draft_players():
-    batter_sql = sa_text("""
+def get_draft_players(league: Optional[str] = None):
+    where_clause = "WHERE league = :league" if league else ""
+    batter_sql = sa_text(f"""
         SELECT player_id, name, position, team, avg, hr, rbi, sb, ab
         FROM batter_caching
+        {where_clause}
     """)
-    pitcher_sql = sa_text("""
+    pitcher_sql = sa_text(f"""
         SELECT player_id, name, position, team, w, sv, so, era, whip, ip
         FROM pitcher_caching
+        {where_clause}
     """)
 
+    params = {"league": league} if league else {}
     with engine.connect() as conn:
-        batter_rows = conn.execute(batter_sql).fetchall()
-        pitcher_rows = conn.execute(pitcher_sql).fetchall()
+        batter_rows = conn.execute(batter_sql, params).fetchall()
+        pitcher_rows = conn.execute(pitcher_sql, params).fetchall()
 
     items_by_id: Dict[int, PlayerSummary] = {}
 


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added a `league` column to `batter_caching` / `pitcher_caching` and tagged each row with its source league during the refresh. Introduced `_BATTER_API_COLUMNS` / `_PITCHER_API_COLUMNS` (fields requested from the external API) separately from `_BATTER_CACHE_COLUMNS` / `_PITCHER_CACHE_COLUMNS` (DB columns = API fields + `league`), and injected `{"league": "AL" | "NL"}` into each row when merging the AL and NL responses in `_sync_cache_table`.
- Exposed an optional `?league=` query parameter on the draft `/players` endpoint. When the caller passes `AL` or `NL`, both the batter and pitcher SELECT statements add `WHERE league = :league`; when omitted, the endpoint still returns the full pool (mixed) as before.

## Why
<!-- Why did you do it? -->
- Draft sessions will let the user pick an MLB league scope (AL-only / NL-only) and the available player pool needs to be filtered accordingly. Storing league as a column on the existing two cache tables is far cheaper than splitting into four tables — schema and `_sync_cache_table` stay essentially the same, every "all players" query keeps working, and a future index on `league` is a one-liner if filtering ever gets hot.
- The frontend needs a stable API hook to drive the league filter once the session-creation UI ships. Adding the `?league=` parameter now (optional, backward-compatible — no existing callers break) means the frontend can wire the filter as soon as the session field lands, without any further backend work or coordination.

## Related Issue
<!-- e.g. #123 -->
- #85 