### PR TITLE
feat: add per-session player notes API

### DIFF
--- a/be/database/note_store.py
+++ b/be/database/note_store.py
@@ -1,0 +1,63 @@
+# CRUD operations for draft_player_notes table.
+# 한 (session_id, player_id) 조합당 메모 1개 — upsert로 덮어쓰기, 빈 문자열로 들어오면 삭제.
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import text
+
+from orm.session import engine
+
+
+def list_notes(session_id: int) -> List[dict]:
+    """세션의 모든 메모를 반환. playerId → note 매핑용."""
+    sql = text("""
+        SELECT player_id, note, updated_at
+        FROM draft_player_notes
+        WHERE session_id = :session_id
+    """)
+    with engine.connect() as conn:
+        rows = conn.execute(sql, {"session_id": session_id}).fetchall()
+    return [
+        {
+            "playerId": r._mapping["player_id"],
+            "note": r._mapping["note"],
+            "updatedAt": r._mapping["updated_at"],
+        }
+        for r in rows
+    ]
+
+
+def upsert_note(session_id: int, user_id: str, player_id: str, note: str) -> dict:
+    """메모 INSERT 또는 UPDATE. 항상 updated_at 갱신.
+    반환값: 저장된 row의 메타데이터 (FE 상태 갱신용)."""
+    now = datetime.utcnow()
+    sql = text("""
+        INSERT INTO draft_player_notes
+            (session_id, user_id, player_id, note, created_at, updated_at)
+        VALUES
+            (:session_id, :user_id, :player_id, :note, :now, :now)
+        ON DUPLICATE KEY UPDATE
+            note = VALUES(note),
+            updated_at = VALUES(updated_at)
+    """)
+    with engine.connect() as conn:
+        conn.execute(sql, {
+            "session_id": session_id,
+            "user_id": user_id,
+            "player_id": player_id,
+            "note": note,
+            "now": now,
+        })
+        conn.commit()
+    return {"playerId": player_id, "note": note, "updatedAt": now}
+
+
+def delete_note(session_id: int, player_id: str) -> None:
+    """메모 삭제. 빈 문자열 저장 요청 시 호출됨."""
+    sql = text("""
+        DELETE FROM draft_player_notes
+        WHERE session_id = :session_id AND player_id = :player_id
+    """)
+    with engine.connect() as conn:
+        conn.execute(sql, {"session_id": session_id, "player_id": player_id})
+        conn.commit()

--- a/be/main.py
+++ b/be/main.py
@@ -16,7 +16,7 @@ from pages.playerinfo import router as players_router
 
 from database.player_cache_store import refresh_player_cache
 from orm.session import engine, Base
-from orm.models import User  # noqa: F401 — import so SQLAlchemy registers the table
+from orm.models import User, DraftPlayerNote  # noqa: F401 — import so SQLAlchemy registers the tables
 
 from dotenv import load_dotenv
 from fastapi import FastAPI

--- a/be/orm/models.py
+++ b/be/orm/models.py
@@ -1,4 +1,12 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from datetime import datetime, timezone
 
 from orm.session import Base
@@ -13,3 +21,32 @@ class User(Base):
     email = Column(String(255), nullable=False)
     name = Column(String(255), nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
+class DraftPlayerNote(Base):
+    """Per-session free-text memo a user can attach to a player.
+    UNIQUE(session_id, player_id) — one note per player per session, upserted.
+    FK on draft_sessions.id with CASCADE so notes auto-delete with the session.
+    """
+    __tablename__ = "draft_player_notes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(
+        Integer,
+        ForeignKey("draft_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(String(100), nullable=False, index=True)
+    player_id = Column(String(20), nullable=False)
+    note = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("session_id", "player_id", name="uq_session_player_note"),
+    )

--- a/be/pages/draft.py
+++ b/be/pages/draft.py
@@ -128,6 +128,22 @@ class PlayerValuesPayload(BaseModel):
     picks: List[PlayerDraftStatusIndex]
 
 
+# ── Player note models ──
+
+class PlayerNoteItem(BaseModel):
+    playerId: str
+    note: str
+    updatedAt: datetime
+
+
+class PlayerNoteList(BaseModel):
+    items: List[PlayerNoteItem]
+
+
+class UpdateNotePayload(BaseModel):
+    note: str
+
+
 # DB position -> draft position mapping
 _DB_POS_TO_DRAFT: Dict[str, DraftPosition] = {
     "C": "C", "1B": "1B", "2B": "2B", "3B": "3B", "SS": "SS",
@@ -149,6 +165,11 @@ from database.draft_store import (
     save_draft_config,
     load_draft_picks,
     replace_session_picks,
+)
+from database.note_store import (
+    list_notes,
+    upsert_note,
+    delete_note,
 )
 
 # Clamps a number to a given range. Ensures user input stays within valid bounds.
@@ -433,7 +454,7 @@ def update_user_session(
     )
 
 
-# 세션 삭제. CASCADE로 config + picks 자동 삭제됨.
+# 세션 삭제. CASCADE로 config + picks + notes 자동 삭제됨.
 @router.delete("/sessions/{session_id}", response_model=dict)
 def delete_user_session(
     session_id: int,
@@ -444,6 +465,53 @@ def delete_user_session(
 
     delete_session(session_id)
     return {"status": "ok", "sessionId": session_id}
+
+
+############################ 선수 메모 #############################
+# 세션의 모든 메모를 한 번에 반환. FE는 playerId → note dict로 변환해서 사용.
+@router.get("/sessions/{session_id}/notes", response_model=PlayerNoteList)
+def list_session_notes(
+    session_id: int,
+    current_user_id: int = Depends(get_user_id),
+):
+    user_id = str(current_user_id)
+    _verify_session_owner(session_id, user_id)
+
+    rows = list_notes(session_id)
+    items = [
+        PlayerNoteItem(
+            playerId=str(r["playerId"]),
+            note=r["note"],
+            updatedAt=r["updatedAt"],
+        )
+        for r in rows
+    ]
+    return PlayerNoteList(items=items)
+
+
+# 메모 upsert (빈 문자열이면 삭제). 한 (session, player) 조합당 메모는 항상 0 또는 1개.
+@router.put("/sessions/{session_id}/notes/{player_id}", response_model=dict)
+def update_session_note(
+    session_id: int,
+    player_id: str,
+    payload: UpdateNotePayload,
+    current_user_id: int = Depends(get_user_id),
+):
+    user_id = str(current_user_id)
+    _verify_session_owner(session_id, user_id)
+
+    note = payload.note.strip()
+    if not note:
+        delete_note(session_id, player_id)
+        return {"status": "deleted", "playerId": player_id}
+
+    saved = upsert_note(session_id, user_id, player_id, note)
+    return {
+        "status": "ok",
+        "playerId": saved["playerId"],
+        "note": saved["note"],
+        "updatedAt": saved["updatedAt"].isoformat(),
+    }
 
 
 ############################ 선수 데이터 #############################


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added a new `DraftPlayerNote` SQLAlchemy ORM model in `be/orm/models.py` with a FK to `draft_sessions.id` (ON DELETE CASCADE) and a UNIQUE(`session_id`, `player_id`) constraint, so a session deletion auto-cleans its notes and only one note can exist per (session, player) pair.
- Registered the new model in `be/main.py` so `Base.metadata.create_all` provisions the `draft_player_notes` table automatically on the next deploy — no manual migration script needed for dev/prod.
- Added `be/database/note_store.py` with three helpers: `list_notes(session_id)` for bootstrap, `upsert_note(...)` (INSERT … ON DUPLICATE KEY UPDATE), and `delete_note(...)`. Mirrors the raw-SQL style of `draft_store.py` for consistency.
- Added two routes to `be/pages/draft.py`:
  - `GET /api/draft/sessions/{session_id}/notes` → `{ items: [{ playerId, note, updatedAt }] }`
  - `PUT /api/draft/sessions/{session_id}/notes/{player_id}` body `{ note: string }` → upsert; empty/whitespace string deletes the note instead.
- Both routes reuse `_verify_session_owner` for auth + 404-on-wrong-user.

## Why
<!-- Why did you do it? -->
- Users have asked for free-text scouting notes next to each player during the draft (e.g. "watch his wrist injury", "$40 max bid"). Scoping notes per session (not globally per user) lets the same player carry different notes in different leagues / configs — which matches how users plan around session-specific constraints (budget, roster size, AL vs NL).
- ORM-managed schema (vs raw `CREATE TABLE`) keeps the migration story coherent now that we already use `create_all` for `users`; one less hand-applied SQL file across dev/prod.
- Empty-string-deletes lets the FE have a single PUT endpoint covering all three user actions (add / edit / clear), simplifying the popover wiring.

## Related Issue
<!-- e.g. #123 -->
- #87