### PR TITLE
feat: player notification system with 15-min polling

### DIFF
--- a/be/database/notification_store.py
+++ b/be/database/notification_store.py
@@ -1,0 +1,71 @@
+# CRUD for the notifications table.
+# Insert is called from two places:
+#   1. delta detection in refresh_player_cache (real injury/depth changes)
+#   2. webhook receiver for fake admin pushes from the Player API
+# list_since is what the FE polls every 15 seconds.
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy import text
+
+from orm.session import engine
+
+
+def insert(
+    event_type: str,
+    player_id: str,
+    message: str,
+    player_name: Optional[str] = None,
+) -> dict:
+    """Insert a notification row. Returns the inserted row metadata so callers
+    can publish in-process (e.g. to an SSE bus) if that's added later."""
+    now = datetime.now(timezone.utc)
+    with engine.begin() as conn:
+        result = conn.execute(
+            text("""
+                INSERT INTO notifications
+                    (event_type, player_id, player_name, message, created_at)
+                VALUES
+                    (:event_type, :player_id, :player_name, :message, :now)
+            """),
+            {
+                "event_type": event_type,
+                "player_id": player_id,
+                "player_name": player_name,
+                "message": message,
+                "now": now,
+            },
+        )
+        return {
+            "id": result.lastrowid,
+            "event_type": event_type,
+            "player_id": player_id,
+            "player_name": player_name,
+            "message": message,
+            "created_at": now,
+        }
+
+
+def list_since(last_id: int = 0, limit: int = 50) -> List[dict]:
+    """Return notifications newer than last_id, oldest first, capped at limit.
+    FE polls this every 15 seconds with the highest id it has seen."""
+    sql = text("""
+        SELECT id, event_type, player_id, player_name, message, created_at
+        FROM notifications
+        WHERE id > :last_id
+        ORDER BY id ASC
+        LIMIT :limit
+    """)
+    with engine.connect() as conn:
+        rows = conn.execute(sql, {"last_id": last_id, "limit": limit}).fetchall()
+    return [
+        {
+            "id": r._mapping["id"],
+            "event_type": r._mapping["event_type"],
+            "player_id": r._mapping["player_id"],
+            "player_name": r._mapping["player_name"],
+            "message": r._mapping["message"],
+            "created_at": r._mapping["created_at"],
+        }
+        for r in rows
+    ]

--- a/be/database/player_cache_store.py
+++ b/be/database/player_cache_store.py
@@ -1,7 +1,11 @@
 # Batter and pitcher cache tables backed by the external PPA API.
 # refresh_player_cache() pulls AL+NL batters and pitchers and upserts local cache.
+# Each refresh also compares the new rows against the cached ones and records
+# notifications for injury_status / depth_order changes (consumed by the FE
+# notification polling endpoint).
 import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import bindparam, text
@@ -69,6 +73,90 @@ def _delete_missing_rows(conn, table_name: str, seen_ids: list[Any]) -> None:
     conn.execute(sql, {"ids": seen_ids})
 
 
+def _detect_and_record_deltas(
+    conn,
+    table_name: str,
+    new_rows: list[dict[str, Any]],
+    label: str,
+) -> None:
+    """Compare new rows against existing cache and INSERT notifications for
+    changes to injury_status or depth_order.
+
+    New player_ids (not yet in cache) emit no notification — that avoids a
+    1000-row flood on the very first refresh after a fresh DB.
+
+    Called inside the same engine.begin() transaction as the UPSERT so the
+    notification insert and cache update succeed or roll back together.
+    """
+    new_by_id = {
+        r["player_id"]: r
+        for r in new_rows
+        if r.get("player_id") is not None
+    }
+    if not new_by_id:
+        return
+
+    sql = text(f"""
+        SELECT player_id, name, injury_status, depth_order
+        FROM {table_name}
+        WHERE player_id IN :ids
+    """).bindparams(bindparam("ids", expanding=True))
+
+    old_rows = conn.execute(sql, {"ids": list(new_by_id.keys())}).fetchall()
+    old_by_id = {r._mapping["player_id"]: r._mapping for r in old_rows}
+
+    events: list[dict[str, Any]] = []
+    for pid, new in new_by_id.items():
+        old = old_by_id.get(pid)
+        if old is None:
+            # 첫 등장 — 알림 없음 (초기 로드 시 폭주 방지)
+            continue
+
+        old_injury = old["injury_status"] or ""
+        new_injury = new.get("injury_status") or ""
+        if old_injury != new_injury:
+            name = new.get("name") or "Player"
+            events.append({
+                "event_type": "INJURY",
+                "player_id": str(pid),
+                "player_name": new.get("name"),
+                "message": (
+                    f"{name}: injury status "
+                    f"{old_injury or 'Active'} → {new_injury or 'Active'}"
+                ),
+            })
+            continue  # injury가 depth보다 우선 — 한 선수당 사이클당 알림 1개로 제한
+
+        old_depth = old["depth_order"]
+        new_depth = new.get("depth_order")
+        if old_depth != new_depth:
+            name = new.get("name") or "Player"
+            events.append({
+                "event_type": "DEPTH",
+                "player_id": str(pid),
+                "player_name": new.get("name"),
+                "message": f"{name}: depth order {old_depth} → {new_depth}",
+            })
+
+    if not events:
+        return
+
+    now = datetime.now(timezone.utc)
+    for ev in events:
+        ev["created_at"] = now
+
+    conn.execute(
+        text("""
+            INSERT INTO notifications
+                (event_type, player_id, player_name, message, created_at)
+            VALUES
+                (:event_type, :player_id, :player_name, :message, :created_at)
+        """),
+        events,
+    )
+    logger.info(f"[{label}] {len(events)} delta notification(s) recorded")
+
+
 def _sync_cache_table(
     *,
     label: str,
@@ -101,9 +189,11 @@ def _sync_cache_table(
         return
 
     seen_ids = [r["player_id"] for r in rows]
-    # UPSERT와 stale-row DELETE를 단일 트랜잭션으로 묶음.
+    # delta 감지 → UPSERT → stale-row DELETE를 단일 트랜잭션으로 묶음.
     # 중간 실패 시 자동 ROLLBACK으로 어제 상태 유지.
+    # delta는 UPSERT 전에 — 그래야 기존 cache와 새 데이터를 비교 가능.
     with engine.begin() as conn:
+        _detect_and_record_deltas(conn, table_name, rows, label)
         _upsert_cache_rows(conn, table_name, columns, rows)
         _delete_missing_rows(conn, table_name, seen_ids)
 

--- a/be/main.py
+++ b/be/main.py
@@ -30,14 +30,18 @@ load_dotenv()
 Base.metadata.create_all(bind=engine)
 
 
-# batter_caching/pitcher_caching 테이블을 매일 04:00 ET (America/New_York, DST 자동 반영)에 갱신.
-# 외부 API에서 AL+NL 타자/투수 목록을 받아 UPSERT.
+# batter_caching/pitcher_caching 테이블을 매 15분마다 갱신.
+# 외부 API(Player API)에서 AL+NL 타자/투수 목록을 받아 UPSERT하고,
+# 동시에 기존 cache와 비교해 injury_status / depth_order 변경된 선수에 대해
+# notifications 테이블에 알림 row를 추가한다 (FE polling이 픽업).
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     scheduler = AsyncIOScheduler()
     scheduler.add_job(
         refresh_player_cache,
-        CronTrigger(hour=4, minute=0, timezone="America/New_York"),
+        CronTrigger(minute="*/15"),
+        id="refresh_player_cache",
+        name="Refresh player cache + emit delta notifications (every 15 min)",
     )
     scheduler.start()
     try:

--- a/be/main.py
+++ b/be/main.py
@@ -16,7 +16,7 @@ from pages.playerinfo import router as players_router
 
 from database.player_cache_store import refresh_player_cache
 from orm.session import engine, Base
-from orm.models import User, DraftPlayerNote  # noqa: F401 — import so SQLAlchemy registers the tables
+from orm.models import User, DraftPlayerNote, Notification  # noqa: F401 — import so SQLAlchemy registers the tables
 
 from dotenv import load_dotenv
 from fastapi import FastAPI

--- a/be/main.py
+++ b/be/main.py
@@ -12,6 +12,7 @@ from auth import router as auth_router
 from pages.draft import router as draft_router
 from pages.home import router as home_router
 from pages.myteam import router as myteam_router
+from pages.notifications import router as notifications_router
 from pages.playerinfo import router as players_router
 
 from database.player_cache_store import refresh_player_cache
@@ -57,6 +58,7 @@ app.include_router(home_router)
 app.include_router(myteam_router)
 app.include_router(draft_router)
 app.include_router(ai_router)
+app.include_router(notifications_router)
 
 
 # 메인 백엔드 서버의 상태 확인.

--- a/be/main.py
+++ b/be/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from pages.admin import router as admin_router
 from pages.ai import router as ai_router
 from auth import router as auth_router
 from pages.draft import router as draft_router
@@ -59,6 +60,7 @@ app.include_router(myteam_router)
 app.include_router(draft_router)
 app.include_router(ai_router)
 app.include_router(notifications_router)
+app.include_router(admin_router)
 
 
 # 메인 백엔드 서버의 상태 확인.

--- a/be/orm/models.py
+++ b/be/orm/models.py
@@ -47,3 +47,24 @@ class DraftPlayerNote(Base):
     __table_args__ = (
         UniqueConstraint("session_id", "player_id", name="uq_session_player_note"),
     )
+
+
+class Notification(Base):
+    """Notification event displayed as a toast in the Draft Kit.
+    Inserts come from two sources:
+      1. delta detection during refresh_player_cache (real changes pulled from api)
+      2. webhook from api's POST /admin/player-event (fake admin push for demos)
+    Browser clients poll GET /api/notifications/recent?since=<id> every 15 seconds.
+    """
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    event_type = Column(String(32), nullable=False)
+    player_id = Column(String(20), nullable=False, index=True)
+    player_name = Column(String(255), nullable=True)
+    message = Column(String(500), nullable=False)
+    created_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )

--- a/be/pages/admin.py
+++ b/be/pages/admin.py
@@ -1,0 +1,87 @@
+# Admin / internal endpoints for the notification system.
+#   POST /internal/notify       — webhook receiver from the Player API
+#                                 (api's POST /admin/player-event forwards here)
+#   POST /admin/notify          — direct fake push from be itself (demo shortcut)
+#   POST /admin/refresh-cache   — force-trigger refresh_player_cache (live demo)
+import logging
+import os
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from database.notification_store import insert as insert_notification
+from database.player_cache_store import refresh_player_cache
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(tags=["admin"])
+
+
+class NotifyPayload(BaseModel):
+    player_id: str
+    message: str
+    event_type: str = "INJURY"
+    player_name: Optional[str] = None
+
+
+def _check_admin_key(request: Request) -> None:
+    admin_secret = os.getenv("ADMIN_SECRET")
+    if not admin_secret:
+        raise HTTPException(status_code=503, detail="ADMIN_SECRET not configured")
+    key = request.headers.get("X-Admin-Key")
+    if not key or key != admin_secret:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Admin-Key")
+
+
+def _check_internal_key(request: Request) -> None:
+    internal_key = os.getenv("INTERNAL_WEBHOOK_KEY")
+    if not internal_key:
+        raise HTTPException(status_code=503, detail="INTERNAL_WEBHOOK_KEY not configured")
+    key = request.headers.get("X-Internal-Key")
+    if not key or key != internal_key:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Internal-Key")
+
+
+@router.post("/internal/notify")
+def receive_notify_webhook(payload: NotifyPayload, request: Request):
+    """Webhook receiver called by the Player API's POST /admin/player-event.
+    Inserts the event into the notifications table so FE polls pick it up."""
+    _check_internal_key(request)
+    inserted = insert_notification(
+        event_type=payload.event_type,
+        player_id=payload.player_id,
+        message=payload.message,
+        player_name=payload.player_name,
+    )
+    logger.info(f"[internal/notify] inserted notification id={inserted['id']}")
+    return {"status": "ok", "id": inserted["id"]}
+
+
+@router.post("/admin/notify")
+def admin_fake_notify(payload: NotifyPayload, request: Request):
+    """Direct fake-push entry on the be side — bypasses the Player API.
+    Useful for demo when api cascade is not set up or for be-only testing."""
+    _check_admin_key(request)
+    inserted = insert_notification(
+        event_type=payload.event_type,
+        player_id=payload.player_id,
+        message=payload.message,
+        player_name=payload.player_name,
+    )
+    logger.info(f"[admin/notify] inserted notification id={inserted['id']}")
+    return {"status": "ok", "id": inserted["id"]}
+
+
+@router.post("/admin/refresh-cache")
+async def admin_refresh_cache(request: Request):
+    """Force-run refresh_player_cache immediately (skip the 15-min wait).
+    Will detect deltas vs current cache and emit notifications inline."""
+    _check_admin_key(request)
+    try:
+        await refresh_player_cache()
+    except Exception as e:
+        logger.error(f"[admin/refresh-cache] failed: {e}")
+        raise HTTPException(status_code=500, detail=f"refresh failed: {e}")
+    return {"status": "refreshed"}

--- a/be/pages/notifications.py
+++ b/be/pages/notifications.py
@@ -1,0 +1,54 @@
+# Public notification endpoint used by the Draft Kit frontend.
+# FE polls GET /api/notifications/recent?since=<id> every 15 seconds and
+# fires a toast for each new event.
+import logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from database.notification_store import list_since
+from security import get_user_id
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter(prefix="/api/notifications", tags=["notifications"])
+
+
+class NotificationItem(BaseModel):
+    id: int
+    event_type: str
+    player_id: str
+    player_name: Optional[str] = None
+    message: str
+    # ISO 8601 string so the FE can hand it straight to new Date(...).
+    created_at: str
+
+
+class NotificationList(BaseModel):
+    items: List[NotificationItem]
+
+
+@router.get("/recent", response_model=NotificationList)
+def list_recent_notifications(
+    since: int = Query(0, ge=0, description="Last id the client has seen"),
+    limit: int = Query(50, ge=1, le=200),
+    current_user_id: int = Depends(get_user_id),  # 인증만 필요 — user_id 자체는 안 씀
+):
+    """Return notifications with id > since, oldest first.
+    FE remembers the highest id it has seen in localStorage and sends it back
+    on every poll. If since=0 (first load), the most recent N events are returned."""
+    rows = list_since(last_id=since, limit=limit)
+    items = [
+        NotificationItem(
+            id=r["id"],
+            event_type=r["event_type"],
+            player_id=str(r["player_id"]),
+            player_name=r["player_name"],
+            message=r["message"],
+            created_at=r["created_at"].isoformat() if r["created_at"] else "",
+        )
+        for r in rows
+    ]
+    return NotificationList(items=items)


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added a \`Notification\` ORM model (\`id\`, \`event_type\`, \`player_id\`, \`player_name\`, \`message\`, \`created_at\`) registered in \`main.py\` so \`Base.metadata.create_all\` provisions the \`notifications\` table automatically on next deploy. No manual migration.
- Added \`be/database/notification_store.py\` with \`insert(...)\` and \`list_since(last_id, limit)\` — both shared by the polling endpoint, the delta-detection logic, and the admin endpoints.
- Added the user-facing polling endpoint \`GET /api/notifications/recent?since=<id>\` (\`be/pages/notifications.py\`). FE will call this every 15 seconds. Auth-gated via the existing \`get_user_id\` Bearer dependency; uses since-id pagination to keep payloads small and survive offline gaps.
- Added admin / internal endpoints (\`be/pages/admin.py\`):
  - \`POST /internal/notify\` — webhook receiver from the Player API's \`POST /admin/player-event\`. \`X-Internal-Key\` auth.
  - \`POST /admin/notify\` — direct fake-push entry on the be side, useful when the Player API cascade is unavailable or for be-only testing. \`X-Admin-Key\` auth.
  - \`POST /admin/refresh-cache\` — force-runs \`refresh_player_cache\` immediately so admins don't have to wait 15 minutes for the live-pulling demo. \`X-Admin-Key\` auth.
- Added delta detection inside \`_sync_cache_table\` in \`be/database/player_cache_store.py\`. Before each UPSERT we SELECT the existing (\`name\`, \`injury_status\`, \`depth_order\`) per player_id and compare to the new rows. Changes are inserted into \`notifications\` in the same transaction as the cache update. New \`player_id\`s (first-time inserts) intentionally do NOT emit notifications — that avoids a 1000-event flood on the first refresh of an empty cache. injury_status changes take priority over depth_order so a single player produces at most one event per cycle.
- Switched the be scheduler in \`main.py\` from "daily 4 AM ET" to "every 15 min" so the user-facing notifications surface within roughly 15 minutes of an upstream change.

## Why
<!-- Why did you do it? -->
- This is the Draft Kit Backend half of the player-notification rubric items (Force notification via API, Draft Kit show pushed state, Notification system alert). McKenna confirmed in Discord that fake status pushes earn points and live pulling earns more — this PR covers both: admins can fake-trigger via \`POST /admin/notify\` or via the Player API's \`POST /admin/player-event\` → webhook cascade, and the live path comes from \`refresh_player_cache\` detecting real injury / depth deltas every 15 minutes.
- A DB-backed event log was preferred over an in-memory queue or SSE so the polling architecture works as a normal stateless HTTP API (no nginx buffering tweaks, JWT in query string, or in-process pub/sub). Persistence also gives free catch-up for users who close their tab overnight — when they come back, the FE sends its last-seen id and gets everything they missed.
- Detecting deltas during \`refresh_player_cache\` (rather than in the Player API itself) keeps the api side simple and means changes flow naturally from the existing pipeline. New-player check (\`old is None\` → skip) was added after thinking through the bootstrap case where the cache table is empty — without it the first deploy would emit ~1300 notifications.

## Related Issue
<!-- e.g. #123 -->
- Closes #90
- Player API counterpart: \`Ppa-Dun-project/PPA-DUN-api#124\` (scheduler split + \`/admin/player-event\`)