### PR TITLE
Feature/keeper

### DIFF
--- a/be/contract_rollover.py
+++ b/be/contract_rollover.py
@@ -1,0 +1,49 @@
+# Keeper / contract 코드의 시즌 롤오버 로직.
+# DB·HTTP 의존 없음 — 순수 함수. 표는 첨부 이미지의 keeper league 기준이며
+# 변경 시 여기 한 곳만 고치면 된다.
+from typing import Literal, Optional
+
+
+# 영입 당시 사용자가 고른 원본 계약 코드. picks 테이블의 contract_code 컬럼과 일치.
+ContractCode = Literal["F3", "F2", "F1", "S1", "L2", "LX", "X"]
+
+
+# 코드별 만료 테이블. {code: [elapsed=0일 때 상태, elapsed=1, ...]}
+# 테이블 끝을 넘긴 elapsed는 모두 "X"로 떨어진다.
+_ROLLOVER_TABLE: dict[str, list[ContractCode]] = {
+    "F3": ["F3", "F2", "F1"],
+    "F2": ["F2", "F1"],
+    "F1": ["F1"],
+    "S1": ["S1"],
+    "L2": ["L2", "LX"],
+    "LX": ["LX"],
+    "X":  [],  # 이미 만료 — 어떤 elapsed에서도 X
+}
+
+
+def rolled_contract(
+    code: Optional[ContractCode],
+    years_elapsed: int,
+) -> Optional[ContractCode]:
+    """영입 당시 코드와 그동안 흐른 시즌 수로 현재 계약 상태를 계산한다.
+
+    - code=None: keeper 정보가 없는 픽(옛 데이터). None 그대로 반환.
+    - years_elapsed < 0: target_season < signed_season인 비정상 입력.
+        과거 재현 시나리오 등에서 발생 가능. 원본 코드를 그대로 반환한다.
+    - 코드별 테이블을 넘어선 elapsed: "X"(만료) 반환.
+
+    이 함수는 정보가 X로 떨어졌는지 알려줄 뿐, 픽을 실제로 제외하는 책임은
+    호출자(import 로직)에 있다.
+    """
+    if code is None:
+        return None
+    if years_elapsed <= 0:
+        return code
+
+    timeline = _ROLLOVER_TABLE.get(code)
+    if timeline is None:
+        # 알 수 없는 코드 — 데이터 오염. 보수적으로 그대로 반환.
+        return code
+    if years_elapsed < len(timeline):
+        return timeline[years_elapsed]
+    return "X"

--- a/be/database/draft_store.py
+++ b/be/database/draft_store.py
@@ -132,17 +132,18 @@ def save_draft_config(
     my_team_name: str,
     opp_team_names: List[str],
     opponents_count: int,
+    target_season: Optional[int] = None,
 ) -> None:
     """Saves draft config for a session (INSERT or UPDATE on duplicate session_id)."""
     now = datetime.utcnow()
     sql = text("""
         INSERT INTO draft_config
             (session_id, user_id, league_type, budget, roster_players,
-             my_team_name, opp_team_names, opponents_count,
+             my_team_name, opp_team_names, opponents_count, target_season,
              created_at, updated_at)
         VALUES
             (:session_id, :user_id, :league_type, :budget, :roster_players,
-             :my_team_name, :opp_team_names, :opponents_count,
+             :my_team_name, :opp_team_names, :opponents_count, :target_season,
              :now, :now)
         ON DUPLICATE KEY UPDATE
             league_type = VALUES(league_type),
@@ -151,6 +152,7 @@ def save_draft_config(
             my_team_name = VALUES(my_team_name),
             opp_team_names = VALUES(opp_team_names),
             opponents_count = VALUES(opponents_count),
+            target_season = VALUES(target_season),
             updated_at = VALUES(updated_at)
     """)
     with engine.connect() as conn:
@@ -163,6 +165,7 @@ def save_draft_config(
             "my_team_name": my_team_name,
             "opp_team_names": json.dumps(opp_team_names),
             "opponents_count": opponents_count,
+            "target_season": target_season,
             "now": now,
         })
         conn.commit()
@@ -188,6 +191,7 @@ def load_draft_config(session_id: int) -> Optional[dict]:
         "my_team_name": r["my_team_name"],
         "opp_team_names": opp_names,
         "opponents_count": r["opponents_count"],
+        "target_season": r["target_season"],
     }
 
 
@@ -196,7 +200,8 @@ def load_draft_config(session_id: int) -> Optional[dict]:
 def load_draft_picks(session_id: int) -> List[dict]:
     sql = text("""
         SELECT player_id, drafted_by_team_id, slot_index,
-               slot_pos, bid, pick_type, kind
+               slot_pos, bid, pick_type, kind,
+               contract_code, signed_season
         FROM draft_picks
         WHERE session_id = :session_id
         ORDER BY id ASC
@@ -214,6 +219,8 @@ def load_draft_picks(session_id: int) -> List[dict]:
             "bid": r._mapping["bid"],
             "type": r._mapping["pick_type"],
             "kind": r._mapping["kind"] or "main",
+            "contractCode": r._mapping["contract_code"],
+            "signedSeason": r._mapping["signed_season"],
         }
         for r in rows
     ]
@@ -225,7 +232,8 @@ def replace_session_picks(
     picks: List[dict],
 ) -> None:
     """세션의 모든 picks를 통째로 교체 (DELETE 후 bulk INSERT). 트랜잭션으로 원자적 처리.
-    각 pick dict 키: player_id, drafted_by_team_id, slot_index, slot_pos, bid, pick_type, kind."""
+    각 pick dict 키: player_id, drafted_by_team_id, slot_index, slot_pos, bid, pick_type,
+    kind, contract_code, signed_season."""
     now = datetime.utcnow()
     with engine.begin() as conn:
         conn.execute(
@@ -237,10 +245,12 @@ def replace_session_picks(
                 text("""
                     INSERT INTO draft_picks
                         (session_id, user_id, player_id, drafted_by_team_id, slot_index,
-                         slot_pos, bid, pick_type, kind, created_at)
+                         slot_pos, bid, pick_type, kind, contract_code, signed_season,
+                         created_at)
                     VALUES
                         (:session_id, :user_id, :player_id, :drafted_by_team_id, :slot_index,
-                         :slot_pos, :bid, :pick_type, :kind, :now)
+                         :slot_pos, :bid, :pick_type, :kind, :contract_code, :signed_season,
+                         :now)
                 """),
                 [
                     {
@@ -253,6 +263,8 @@ def replace_session_picks(
                         "bid": p["bid"],
                         "pick_type": p["pick_type"],
                         "kind": p.get("kind") or "main",
+                        "contract_code": p.get("contract_code"),
+                        "signed_season": p.get("signed_season"),
                         "now": now,
                     }
                     for p in picks

--- a/be/database/player_cache_store.py
+++ b/be/database/player_cache_store.py
@@ -20,22 +20,18 @@ logger = logging.getLogger(__name__)
 _BATTER_API_COLUMNS = (
     "player_id", "name", "position", "team",
     "primary_number", "birth_date", "birth_city", "birth_country",
-    "height", "weight", "current_age", "mlb_debut_date",
-    "bat_side", "pitch_hand",
-    "ab", "r", "h", "single", "double", "triple",
-    "hr", "rbi", "bb", "k", "sb", "cs",
-    "avg", "obp", "slg",
+    "height", "weight", "current_age", "mlb_debut_date","bat_side", "pitch_hand",
+    "ab", "r", "h", "single", "double", "triple", "hr", "rbi", "bb", "k", "sb", "cs","avg", "obp", "slg",
     "injury_status", "depth_order", "player_value",
 )
 
 _PITCHER_API_COLUMNS = (
     "player_id", "name", "position", "team",
-    "w", "sv", "so", "era", "whip", "ip",
-    "injury_status", "depth_order", "player_value",
-    "l", "g", "gs", "war", "fip", "h", "r", "er", "hr", "bb", "hbp", "bf",
-    "era_plus", "h9", "hr9", "bb9", "so9", "so_bb",
     "primary_number", "birth_date", "birth_city", "birth_country",
     "height", "weight", "current_age", "mlb_debut_date", "pitch_hand",
+    "w", "sv", "so", "era", "whip", "ip", "l", "g", "gs", "war", "fip", "h", "r", "er", 
+    "hr", "bb", "hbp", "bf", "era_plus", "h9", "hr9", "bb9", "so9", "so_bb",
+    "injury_status", "depth_order", "player_value",
 )
 
 # DB 캐시 테이블에 저장하는 컬럼 = API 필드 + 우리가 태깅하는 league

--- a/be/pages/draft.py
+++ b/be/pages/draft.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Dict, List, Literal, Optional, Tuple
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from contract_rollover import ContractCode
 from database.draft_store import load_draft_config
 from orm.session import engine
 from ppa_api.ppa_client import ApiError, build_ppa_api_client
@@ -56,6 +57,8 @@ class DraftConfig(BaseModel):
     myTeamName: str
     opponentsCount: int
     oppTeamNames: List[str]
+    # keeper 롤오버의 기준 시즌. 옛 세션에는 없어 None일 수 있음.
+    targetSeason: Optional[int] = None
 
 # 사용자와 상대의 각 생성된 정보
 class DraftTeam(BaseModel):
@@ -88,6 +91,10 @@ class PlayerDraftStatus(BaseModel):
     type: DraftPickType
     # 메인/마이너/택시 보드 구분. 옛 데이터 호환을 위해 default "main".
     kind: DraftPickKind = "main"
+    # Keeper 계약 코드 (영입 당시 원본). 내 픽 이외(상대팀/마이너/택시)는 None.
+    contractCode: Optional[ContractCode] = None
+    # 이 픽이 영입된 세션의 target_season. rollover 계산에 사용.
+    signedSeason: Optional[int] = None
 
 
 # 선수의 픽 상태 (어떤 팀이 픽했는지, 어떤 포지션에 배치됐는지, 가격은 얼마인지 등)
@@ -234,6 +241,8 @@ def normalize_pick_team_ids(picks: List[PlayerDraftStatusIndex]) -> List[PlayerD
             bid=p.bid,
             type=p.type,
             kind=p.kind,
+            contractCode=p.contractCode,
+            signedSeason=p.signedSeason,
         )
         for p in picks
     ]
@@ -257,6 +266,8 @@ def get_session_picks(session_id: int) -> List[PlayerDraftStatusIndex]:
             bid=r["bid"],                         # 입찰되었던 가격
             type=r["type"],                       # 픽 유형
             kind=r.get("kind") or "main",         # 보드 구분 (옛 행은 main 폴백)
+            contractCode=r.get("contractCode"),   # keeper 계약 코드 (영입 당시 원본)
+            signedSeason=r.get("signedSeason"),   # 영입 세션의 target_season
         )
         for r in rows
     ]
@@ -270,6 +281,7 @@ def normalized_config(
     my_team_name: str,
     opp_team_names: List[str],
     opponents_count: int,
+    target_season: Optional[int] = None,
 ) -> Tuple[DraftConfig, List[DraftTeam]]:
 
     # 사용자가 최대, 최소 범위를 벗어날 경우 normalization
@@ -295,6 +307,7 @@ def normalized_config(
         myTeamName=teams[0].name,
         opponentsCount=normalized_opponents,
         oppTeamNames=opps,
+        targetSeason=target_season,
     )
 
     # 드래프트 설정 정보 + 전체 팀 정보 반환
@@ -321,6 +334,8 @@ def _picks_to_dicts(picks: List[PlayerDraftStatusIndex]) -> List[dict]:
             "bid": p.bid,
             "pick_type": p.type,
             "kind": p.kind,
+            "contract_code": p.contractCode,
+            "signed_season": p.signedSeason,
         }
         for p in picks
     ]
@@ -362,6 +377,7 @@ def create_user_session(
         my_team_name=payload.config.myTeamName,
         opp_team_names=payload.config.oppTeamNames,
         opponents_count=payload.config.opponentsCount,
+        target_season=payload.config.targetSeason,
     )
 
     name = payload.name.strip() or "Untitled Draft"
@@ -380,6 +396,7 @@ def create_user_session(
         my_team_name=config.myTeamName,
         opp_team_names=config.oppTeamNames,
         opponents_count=config.opponentsCount,
+        target_season=config.targetSeason,
     )
 
     picks = normalize_pick_team_ids(payload.picks)
@@ -415,6 +432,7 @@ def get_session_detail(
         my_team_name=config_row["my_team_name"],
         opp_team_names=config_row["opp_team_names"] or [],
         opponents_count=config_row["opponents_count"],
+        target_season=config_row.get("target_season"),
     )
 
     picks = get_session_picks(session_id)
@@ -452,6 +470,7 @@ def update_user_session(
         my_team_name=config_row["my_team_name"],
         opp_team_names=config_row["opp_team_names"] or [],
         opponents_count=config_row["opponents_count"],
+        target_season=config_row.get("target_season"),
     )
     return SessionDetail(
         id=session_id,

--- a/init.sql
+++ b/init.sql
@@ -5,7 +5,7 @@
 -- 사용법:
 --   mysql -u <user> -p <database> < init.sql
 --
--- 최종 업데이트: 2026-04-08
+-- 최종 업데이트: 2026-05-17
 -- ============================================================
 
 -- ------------------------------------------------------------
@@ -133,6 +133,7 @@ CREATE TABLE IF NOT EXISTS `draft_config` (
     `my_team_name`    VARCHAR(100)  DEFAULT NULL,
     `opp_team_names`  JSON          DEFAULT NULL,
     `opponents_count` INT           DEFAULT NULL,
+    `target_season`   INT           DEFAULT NULL,
     `created_at`      DATETIME      DEFAULT NULL,
     `updated_at`      DATETIME      DEFAULT NULL,
     PRIMARY KEY (`user_id`)
@@ -150,6 +151,9 @@ CREATE TABLE IF NOT EXISTS `draft_picks` (
     `slot_pos`            VARCHAR(10)   DEFAULT NULL,
     `bid`                 INT           DEFAULT NULL,
     `pick_type`           VARCHAR(10)   DEFAULT NULL,
+    `kind`                VARCHAR(10)   NOT NULL DEFAULT 'main',
+    `contract_code`       VARCHAR(4)    DEFAULT NULL,
+    `signed_season`       INT           DEFAULT NULL,
     `created_at`          DATETIME      DEFAULT NULL,
     PRIMARY KEY (`id`),
     UNIQUE KEY `uq_user_player` (`user_id`, `player_id`),


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Schema: Added contract_code VARCHAR(4) and signed_season INT to draft_picks, plus target_season INT to draft_config. contract_code stores the original keeper code at signing (F3/F2/F1/S1/L2/LX/X), signed_season records the fantasy season the pick was acquired in, and target_season marks the season the draft session is built for.

- Pydantic + CRUD + domain module: Extended DraftConfig with targetSeason and PlayerDraftStatus with contractCode/signedSeason; updated save_draft_config, load_draft_config, load_draft_picks, and replace_session_picks to read/write the new columns. Added a new be/contract_rollover.py module exposing a ContractCode literal and a pure rolled_contract(code, years_elapsed) function that resolves the current keeper state from a single static table.

## Why
<!-- Why did you do it? -->
- Keeper leagues require carrying players across seasons with a contract that decays year by year; persisting the original code + signing season (instead of the rolled value) keeps historical picks immutable and lets the UI/derivative sessions recompute the current state for any target season without lossy mutations.

## Related Issue
<!-- e.g. #123 -->
- #96 
